### PR TITLE
Program security key without needing an SD card

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -323,6 +323,7 @@ void zuluide_setup(void)
         first_run = false;
         blinkStatus(BLINK_ERROR_NO_SD_CARD);
         blink_poll();
+        platform_poll();
     }
 }
 


### PR DESCRIPTION
This fix allows both the programming of the security key and logging over the USB virtual com port, before an SD card is inserted.