### PR TITLE
Add ATAPI command "read sub channel"

### DIFF
--- a/src/atapi_constants.h
+++ b/src/atapi_constants.h
@@ -31,6 +31,7 @@ X(ATAPI_CMD_VERIFY10                      , 0x2F) \
 X(ATAPI_CMD_SYNCHRONIZE_CACHE             , 0x35) \
 X(ATAPI_CMD_WRITE_BUFFER                  , 0x3B) \
 X(ATAPI_CMD_READ_BUFFER                   , 0x3C) \
+X(ATAPI_CMD_READ_SUB_CHANNEL              , 0x42) \
 X(ATAPI_CMD_READ_TOC                      , 0x43) \
 X(ATAPI_CMD_READ_HEADER                   , 0x44) \
 X(ATAPI_CMD_GET_CONFIGURATION             , 0x46) \

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -20,6 +20,7 @@ protected:
     virtual bool atapi_set_cd_speed(const uint8_t *cmd);
     virtual bool atapi_read_disc_information(const uint8_t *cmd);
     virtual bool atapi_read_track_information(const uint8_t *cmd);
+    virtual bool atapi_read_sub_channel(const uint8_t *cmd);
     virtual bool atapi_read_toc(const uint8_t *cmd);
     virtual bool atapi_read_header(const uint8_t *cmd);
     virtual bool atapi_read_cd(const uint8_t *cmd);
@@ -28,6 +29,11 @@ protected:
     bool doReadTOC(bool MSF, uint8_t track, uint16_t allocationLength);
     bool doReadSessionInfo(bool MSF, uint16_t allocationLength);
     bool doReadFullTOC(uint8_t session, uint16_t allocationLength, bool useBCD);
+    bool doReadSubChannel(bool time, bool subq, uint8_t parameter, uint8_t track_number, uint16_t allocation_length);
+
+
+    void cdromGetAudioPlaybackStatus(uint8_t *status, uint32_t *current_lba, bool current_only);
+
 
     // Read handling, possible conversion of sector formats
     struct {

--- a/src/ide_imagefile.cpp
+++ b/src/ide_imagefile.cpp
@@ -221,6 +221,16 @@ uint64_t IDEImageFile::capacity()
     return m_capacity;
 }
 
+uint64_t IDEImageFile::file_position()
+{
+    return m_file.position();
+}
+
+bool IDEImageFile::is_open()
+{
+    return m_file.isOpen();
+}
+
 bool IDEImageFile::writable()
 {
     return !m_read_only;

--- a/src/ide_imagefile.h
+++ b/src/ide_imagefile.h
@@ -74,6 +74,8 @@ public:
 
     virtual bool get_filename(char *buf, size_t buflen);
     virtual uint64_t capacity();
+    virtual uint64_t file_position();
+    virtual bool is_open();
     virtual bool writable();
     virtual bool read(uint64_t startpos, size_t blocksize, size_t num_blocks, Callback *callback);
     virtual bool write(uint64_t startpos, size_t blocksize, size_t num_blocks, Callback *callback);


### PR DESCRIPTION
Implemented Read Sub Channel command by importing code from the ZuluSCSI firmware and massaging it to fit ZuluIDE firmware.

In method cdromGetAudioPlaybackStatus on line [745](https://github.com/rabbitholecomputing/ZuluIDE-firmware/blob/9e925f31c8fc5a291edccecd7334e878a2e838dd/src/ide_cdrom.cpp#L745) in ide_cdrom.cpp there is a macro switch for the define ENABLE_AUDIO_OUTPUT with code for CD audio playback that is unaltered from ZuluSCSI firmware.

It should be changed when audio playback is implemented on the ZuluIDE, otherwise it can be removed to make the code cleaner.