### PR TITLE
Boot as CD-ROM when no SD card is inserted

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -764,7 +764,7 @@ bool IDEATAPIDevice::atapi_start_stop_unit(const uint8_t *cmd)
         if ((ATAPI_START_STOP_START & cmd_eject) == 0 && m_removable.ejected == false)
         {
             logmsg("Device ejecting media");
-            m_image->load_next_image();
+            if (m_image) m_image->load_next_image();
             m_devinfo.media_status_events = ATAPI_MEDIA_EVENT_REMOVED;
             m_removable.ejected = true;
         }


### PR DESCRIPTION
If there is no SD card the device acts as a CD-ROM drive, thus not stalling the IDE boot sequence.

Ejecting and inserting the SD card results in the first CD image being loaded.