### PR TITLE
Fix/image sorting

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -251,10 +251,7 @@ void load_image()
     
     // Find image file
     char imagefile[MAX_FILE_PATH];
-    if (g_ide_imagefile.find_next_image("/", NULL, imagefile, sizeof(imagefile)))
-    {
-        found_image = true;
-    }
+    found_image = g_ide_imagefile.find_next_image("/", NULL, imagefile, sizeof(imagefile));
 
     switch (g_ide_imagefile.get_drive_type())
     {

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -764,7 +764,11 @@ bool IDEATAPIDevice::atapi_start_stop_unit(const uint8_t *cmd)
         if ((ATAPI_START_STOP_START & cmd_eject) == 0 && m_removable.ejected == false)
         {
             logmsg("Device ejecting media");
-            if (m_image) m_image->load_next_image();
+            if (m_image)
+            {
+                m_image->load_next_image();
+                set_image(m_image);
+            }
             m_devinfo.media_status_events = ATAPI_MEDIA_EVENT_REMOVED;
             m_removable.ejected = true;
         }

--- a/src/ide_imagefile.h
+++ b/src/ide_imagefile.h
@@ -111,7 +111,7 @@ public:
     virtual bool load_next_image();
 
     // Find next image in alphabetical order. If prev_image is NULL, find the first image
-    virtual bool find_next_image(const char *directory, const char *prev_image, char *result, size_t buflen, bool lone_image = false);
+    virtual bool find_next_image(const char *directory, const char *prev_image, char *result, size_t buflen);
     virtual bool find_next_prefix_image(const char *directory, const char *prev_image, char *result, size_t buflen);
 
     // Set drive type for filtering purposes
@@ -137,7 +137,6 @@ protected:
 
     char m_prefix[5];
     drive_type_t m_drive_type;
-    bool m_lone_image;
 
     struct sd_cb_state_t {
         IDEImage::Callback *callback;


### PR DESCRIPTION
Images with a CDRM, ZIPD, and REMV prefix will now load alphabetically.
It will go to the next image in alphabetical order when ejected and
wrap to the first image when the last one is ejected.

If more than one prefix is found, it will choose one and log if it
found others and is ignoring them.

When the prefix isn't defined, all files except the ones on the
ignore list will be sorted  alphabetically for ejection ordering
purposes including files that have no extensions. The ignore
list include: known compression extensions, document extensions,
and any file with the prefix `zulu`.