### PR TITLE
Add ATA Device Reset support

### DIFF
--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -143,6 +143,7 @@ protected:
     virtual bool cmd_set_features(ide_registers_t *regs);
     virtual bool cmd_identify_packet_device(ide_registers_t *regs);
     virtual bool cmd_packet(ide_registers_t *regs);
+    virtual bool cmd_device_reset(ide_registers_t *regs);
 
     // Methods used by ATAPI command implementations
 


### PR DESCRIPTION
The fix set the registers properly for the ATA command Device Reset. It doesn't release the IDE signals it is supposed to when the command is issued, but it does work to boot the OAKCDROM DOS CD-ROM driver.

The other fix to get the DOS driver to work is returning the error bit in the ATA status register for signature returning ATA commands. Specifically when Device Identify is aborted because the device uses the
 ATA Packet command and the proper command for ident is Device Packet
 Identify.