### PR TITLE
Add back Execute Device Diagnostic return method

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -78,6 +78,7 @@ bool IDEATAPIDevice::handle_command(ide_registers_t *regs)
         case IDE_CMD_READ_SECTORS_EXT:
             return set_device_signature(IDE_ERROR_ABORT, false);
         case IDE_CMD_EXECUTE_DEVICE_DIAGNOSTIC:
+            return set_device_signature(IDE_ERROR_EXEC_DEV_DIAG_DEV0_PASS, false);
         // Supported IDE commands
         case IDE_CMD_NOP: return cmd_nop(regs);
         case IDE_CMD_SET_FEATURES: return cmd_set_features(regs);


### PR DESCRIPTION
Accidentally dropped handling of the ATA command Execute Device Diagnostic. This adds back the signature return along with the proper value in the error register.