### PR TITLE
Log fix issue117

### DIFF
--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -92,6 +92,10 @@ namespace zuluide::i2c {
        succesful, otherwise false.
      */
     bool CheckForDevice();
+    /**
+       True iff the SSID and and password have been set.
+     */
+    bool WifiCredentialsSet();
   private:
     TwoWire* wire;
     DeviceControlSafe* deviceControl;

--- a/lib/ZuluControl/src/i2c/i2c_server.cpp
+++ b/lib/ZuluControl/src/i2c/i2c_server.cpp
@@ -75,8 +75,6 @@ void I2CServer::HandleUpdate(const SystemStatus& current) {
   status = current.ToJson();
   if (isSubscribed) {
     writeLengthPrefacedString(wire, I2C_SERVER_SYSTEM_STATUS_JSON, status.length(), status.c_str());
-  } else {
-    logmsg("Received an update, but I2C client is not subscribed.");
   }
 }
 

--- a/lib/ZuluControl/src/i2c/i2c_server.cpp
+++ b/lib/ZuluControl/src/i2c/i2c_server.cpp
@@ -225,6 +225,10 @@ void I2CServer::Poll() {
     if (ReadInLength(wire) != 0) {
       logmsg("Length was not 0 for fetch ssid request.");
     }
+
+    if (!WifiCredentialsSet()) {
+      logmsg("Client requested the WiFi SSID, but the SSID is not configured.");
+    }
         
     writeLengthPrefacedString(wire, I2C_SERVER_SSID, ssid.length(), ssid.c_str());
     break;
@@ -234,6 +238,10 @@ void I2CServer::Poll() {
     wire->requestFrom(CLIENT_ADDR, 2);
     if (ReadInLength(wire) != 0) {
       logmsg("Length was not 0 for fetch ssid pass request.");
+    }
+
+    if (!WifiCredentialsSet()) {
+      logmsg("Client requested SSID password, but the SSID password is not configured.");
     }
     
     writeLengthPrefacedString(wire, I2C_SERVER_SSID_PASS, password.length(), password.c_str());
@@ -293,4 +301,8 @@ void I2CServer::SetSSID(std::string& value) {
 
 void I2CServer::SetPassword(std::string &value) {
   password = value;
+}
+
+bool I2CServer::WifiCredentialsSet() {
+  return !ssid.empty() && !password.empty();
 }

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -185,7 +185,12 @@ bool platform_check_for_controller()
   bool hasHardwareUI = g_rotary_input.CheckForDevice();
   bool hasI2CServer = g_I2cServer.CheckForDevice();
   logmsg(hasHardwareUI ? "Hardware UI found." : "Hardware UI not found.");
-  logmsg(hasI2CServer ? "I2C server Found" : "I2C server not found");
+  logmsg(hasI2CServer ? "I2C server found" : "I2C server not found");
+  if (hasI2CServer && !g_I2cServer.WifiCredentialsSet()) {
+    // The I2C server responded but we cannot configure wifi. This may cause issues.
+    logmsg("An I2C client was detected but the WIFI credentials are not configured. This will cause problems if the I2C client needs WIFI configuration data.");
+  }
+  
   return hasHardwareUI || hasI2CServer;
 }
 

--- a/lib/ZuluIDE_platform_RP2040/display_ssd1306.cpp
+++ b/lib/ZuluIDE_platform_RP2040/display_ssd1306.cpp
@@ -133,15 +133,6 @@ void DisplaySSD1306::updateDisplay() {
 
     // Set the time of the next refresh.
     nextRefresh = make_timeout_time_ms(SCROLL_INTERVAL_MS);
-  } else {
-    // Show loading message.
-    if (!currentDispState && !currentSysStatus) {
-      logmsg("Received an update when display and system status is not set.");
-    } else if (!currentDispState) {
-      logmsg("Received an update when display is not set.");
-    } else {
-      logmsg("Received an update when system status is not set.");
-    }
   }
 }
 


### PR DESCRIPTION
Improved logging when WiFi is not configured.
Removed log messages that were not useful and were confusing.