### PR TITLE
Implement support for .cue/.bin images with multiple .bin files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Image files
 
 Any file on the [ignored list](#ignored-list) will not be used as an device image.
 
+CD-ROM `.bin/.cue` images
+-------------------------
+Image files in `.bin/.cue` format that have only a single `.bin` data file can be placed directly in root folder of the SD card.
+Both the `.bin` and `.cue` should have the same name, and the name specified in `.cue` is ignored.
+
+Image files that have one `.cue` file and multiple `.bin` files should be placed in a subfolder.
+The `.bin` file is located by the name given in the `.cue` text file.
+The name of the folder is used as the name when switching images in alphabetical order.
+
 Cycling Images
 --------------
 Currently the only way to cycle to the next image for a removable device is the eject the medium via the operating system. This will load the next valid file in alphabetic order.

--- a/lib/ZuluControl/src/images/image_iterator.cpp
+++ b/lib/ZuluControl/src/images/image_iterator.cpp
@@ -257,9 +257,25 @@ bool ImageIterator::IsLast() {
   return currentIsLast;
 }
 
+static bool folderContainsCueSheet(FsFile &dir)
+{
+  FsFile file;
+  char filename[MAX_FILE_PATH + 1];
+  while (file.openNext(&dir, O_RDONLY))
+  {
+    if (file.getName(filename, sizeof(filename)) &&
+        (strncasecmp(filename + strlen(filename) - 4, ".cue", 4) == 0))
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 static bool fileIsValidImage(FsFile& file, const char* fileName) {
-  // Skip directories.
-  if (file.isDirectory()) {
+  // Directories are allowed if they contain a .cue sheet
+  if (file.isDirectory() && !folderContainsCueSheet(file)) {
     return false;
   }
 

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -725,6 +725,11 @@ bool IDEATAPIDevice::atapi_cmd_not_ready_error()
 
 bool IDEATAPIDevice::atapi_cmd_error(uint8_t sense_key, uint16_t sense_asc)
 {
+    if (m_atapi_state.data_state == ATAPI_DATA_WRITE)
+    {
+        ide_phy_stop_transfers();
+    }
+
     if (sense_key == ATAPI_SENSE_UNIT_ATTENTION)
     {
         dbgmsg("-- Reporting UNIT_ATTENTION condition after reset/medium change (ASC:", sense_asc, ")");

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -131,11 +131,11 @@ protected:
     } m_removable;
 
     // Buffer used for responses, ide_phy code benefits from this being aligned to 32 bits
-    // Enough for any inquiry/mode response and for up to one CD sector.
+    // Enough for any inquiry/mode response and for up to one CD sector with Q subchannel
     union {
-        uint32_t dword[588];
-        uint16_t word[1176];
-        uint8_t bytes[2352];
+        uint32_t dword[592];
+        uint16_t word[1184];
+        uint8_t bytes[2368];
     } m_buffer;
 
     // IDE command handlers

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -107,10 +107,15 @@ protected:
     // Access data from CUE sheet, or dummy data if no cue sheet provided
     char m_cuesheet[1024];
     CUEParser m_cueparser;
-    bool loadAndValidateCueSheet(const char *cuesheetname);
+    bool loadAndValidateCueSheet(FsFile *dir, const char *cuesheetname);
     bool getFirstLastTrackInfo(CUETrackInfo &first, CUETrackInfo &last);
     uint32_t getLeadOutLBA(const CUETrackInfo* lasttrack);
     CUETrackInfo getTrackFromLBA(uint32_t lba);
+
+    // If the .cue file has data split across multiple files,
+    // this function will reopen m_imagefile when track is changed.
+    int m_selected_file_index;
+    bool selectBinFileForTrack(const CUETrackInfo *track);
 
     // ATAPI configuration pages
     virtual size_t atapi_get_configuration(uint16_t feature, uint8_t *buffer, size_t max_bytes) override;


### PR DESCRIPTION
Added support for cue sheets that reference multiple bin files. (#115)

Such sets must be placed in their own subfolder so that the .bin files do not get mistaken for stand-alone .bin files.