### PR TITLE
Add MODE2/2352 support

### DIFF
--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -1309,6 +1309,13 @@ bool IDECDROMDevice::doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type
             m_cd_read_format.sector_data_length = 2352;
             m_cd_read_format.sector_length_out = 2352;
         }
+        else if (trackinfo.track_mode == CUETrack_MODE2_2352 && main_channel == 0x10)
+        {
+            m_cd_read_format.sector_length_file = 2352;
+            m_cd_read_format.sector_data_skip = 24;
+            m_cd_read_format.sector_data_length = 2048;
+            m_cd_read_format.sector_length_out = 2048;
+        }
         else
         {
             dbgmsg("---- Unsupported channel request for track type ", (int)trackinfo.track_mode);
@@ -1493,7 +1500,8 @@ bool IDECDROMDevice::loadAndValidateCueSheet(FsFile *dir, const char *cuesheetna
 
         if (trackinfo->track_mode != CUETrack_AUDIO &&
             trackinfo->track_mode != CUETrack_MODE1_2048 &&
-            trackinfo->track_mode != CUETrack_MODE1_2352)
+            trackinfo->track_mode != CUETrack_MODE1_2352 &&
+            trackinfo->track_mode != CUETrack_MODE2_2352)
         {
             logmsg("---- Warning: track ", trackinfo->track_number, " has unsupported mode ", (int)trackinfo->track_mode);
         }


### PR DESCRIPTION
This PR adds initial support for MODE2/2352 tracks in cuefiles. 

Tested by using and installing [Nam (USA)](http://redump.org/disc/21233/):
- Works with the VIDECDD.SYS driver in DOS
- Works in Windows 98 SE
- Does not work with OAKCDROM.SYS in DOS. While it now displays the volume label, there are no contents. I haven't debugged that further, but another change is likely needed within ZuluIDE as the original physical disc works fine with this driver. 

[zululog_nam_modified_oakcdrom.txt](https://github.com/user-attachments/files/17693275/zululog_nam_modified_oakcdrom.txt)
[zululog_nam_modified_videcdd.txt](https://github.com/user-attachments/files/17693276/zululog_nam_modified_videcdd.txt)
[zululog_nam_orig.txt](https://github.com/user-attachments/files/17693277/zululog_nam_orig.txt)

References:
- https://github.com/libyal/libodraw/blob/main/documentation/Optical%20disc%20RAW%20format.asciidoc#cd-rom-xa-form-1