### PR TITLE
Fix issue with MS-DOS videcdd CD-ROM driver

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -730,7 +730,7 @@ bool IDEATAPIDevice::atapi_cmd_error(uint8_t sense_key, uint16_t sense_asc)
     // a media change. This allows not ready to be emitted once and then goes to a normal state
     if (sense_key == ATAPI_SENSE_NOT_READY && m_atapi_state.not_ready && is_medium_present())
     {
-        m_atapi_state.not_ready = false;
+        set_not_ready(false);
     }
 
     if (m_atapi_state.data_state == ATAPI_DATA_WRITE)
@@ -783,7 +783,7 @@ bool IDEATAPIDevice::atapi_cmd_ok()
     regs.lba_mid = 0xFE;
     regs.lba_high = 0xFF;
     ide_phy_set_regs(&regs);
-    ide_phy_assert_irq(IDE_STATUS_DEVRDY);
+    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
 
     return true;
 }
@@ -1362,7 +1362,7 @@ void IDEATAPIDevice::insert_media(IDEImage *image)
         {
             set_image(image);
             m_removable.ejected = false;
-            m_atapi_state.not_ready = true;
+            set_not_ready(true);
         }
         else if (m_removable.ejected)
         {
@@ -1396,7 +1396,7 @@ void IDEATAPIDevice::insert_media(IDEImage *image)
                     set_image(&g_ide_imagefile);
                     logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
                     m_removable.ejected = false;
-                    m_atapi_state.not_ready = true;
+                    set_not_ready(true);
                 }
             }
             img_iterator.Cleanup();
@@ -1430,4 +1430,10 @@ void IDEATAPIDevice::set_inquiry_strings(const char* default_vendor, const char*
     memset(input_str, ' ', 4);
     input_len = ini_gets("IDE","atapi_version", default_version, input_str, 5, CONFIGFILE);
     memcpy(m_devinfo.atapi_version, input_str, input_len);
+}
+
+void IDEATAPIDevice::set_not_ready(bool not_ready)
+{
+    if (ini_getbool("IDE", "set_not_ready_on_insert", 0, CONFIGFILE))
+        m_atapi_state.not_ready = not_ready;
 }

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -208,4 +208,7 @@ protected:
 
     // ATAPI standard inquiry string settings
     void set_inquiry_strings(const char* default_vendor, const char* default_product, const char* default_version);
+
+    // Set not ready if enabled via config ini
+    virtual void set_not_ready(bool not_ready);
 };

--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -1588,7 +1588,7 @@ void IDECDROMDevice::insert_media(IDEImage *image)
             set_image(image);
             set_esn_event(esn_event_t::MNewMedia);
             m_removable.ejected = false;
-            m_atapi_state.not_ready = true;
+            set_not_ready(true);
         }
         else if (m_removable.ejected)
         {
@@ -1624,7 +1624,7 @@ void IDECDROMDevice::insert_media(IDEImage *image)
                     logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
                     set_esn_event(esn_event_t::MNewMedia);
                     m_removable.ejected = false;
-                    m_atapi_state.not_ready = true;
+                    set_not_ready(true);
                 }
             }
             img_iterator.Cleanup();

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -27,6 +27,7 @@
 # reinsert_media_after_eject = 1 # Automatically reinsert media after eject
 # reinsert_media_on_inquiry = 1  # Automaitcally reinsert media on inquiry command
 # reinsert_media_on_sd_insert = 0 # Set to 1 to reinsert media when the SD card is inserted after eject
+# set_not_ready_on_insert = 0 # Set to 1 to have the next ATAPI command report not ready - may help with some OSes detecting a CD change
 
 # ignore_command_interrupt = 1 # Ignore a new command interrupting the current one
 # atapi_intrq = 1 # enables the INTRQ signal during a PACKET cmd, some systems need it disabled, default enabled. See documentation for specifics


### PR DESCRIPTION
The driver would take a few seconds to `dir` the first time. This issue was resolved by returning the ATA status register with a Disk Seek Complete (0x10) ORed with the standard Disk Ready (0x40).

Another issue was uncovered once first bug was squashed. An ATAPI error `Not Ready` was issued one time on the next ATAPI command after a media change (disc insert). The videcdd driver immediately fails on the next `dir`. The `Not Ready` functionality is now a `zuluide.ini` setting under `[IDE]` as `set_not_ready_on_insert` which is false or 0 by default, but can be set to 1 or true to enable the `Not Ready` functionality.