### PR TITLE
Load last image on initialization

### DIFF
--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -50,7 +50,7 @@ namespace zuluide::images {
     bool MoveLast();
     // Sets Interator to file
     // return true if successful
-    bool MoveToFile(char *filename);
+    bool MoveToFile(const char *filename);
     bool IsEmpty();
     int GetFileCount();
     void Reset();

--- a/lib/ZuluControl/src/images/image_iterator.cpp
+++ b/lib/ZuluControl/src/images/image_iterator.cpp
@@ -201,7 +201,7 @@ bool ImageIterator::MoveLast()
   return false;
 }
 
-bool ImageIterator::MoveToFile(char *filename)
+bool ImageIterator::MoveToFile(const char *filename)
 {
   if (currentFile.open(&root, filename, O_RDONLY))
   {

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -259,7 +259,7 @@ void platform_set_display_controller(zuluide::Observable<zuluide::control::Displ
 }
 
 void platform_set_input_interface(zuluide::control::InputReceiver* inputReceiver) {
-  logmsg("Inialized platform controller with input receiver.");
+  logmsg("Initialized platform controller with input receiver.");
   g_rotary_input.SetReciever(inputReceiver);
   g_rotary_input.StartSendingEvents();
 }

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,7 +27,7 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2024.11.07"
+#define FW_VER_NUM      "2024.11.12"
 #define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
@@ -36,6 +36,7 @@
 #define LOGFILE     "zululog.txt"
 #define CRASHFILE   "zuluerr.txt"
 #define LICENSEFILE "zuluide.lic"
+#define LASTFILE    "zululast.txt"
 
 // Maximum path length for files on SD card
 #define MAX_FILE_PATH 255

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -26,6 +26,10 @@
 #include "ZuluIDE_config.h"
 #include <minIni.h>
 #include <zuluide/images/image_iterator.h>
+#include <status/status_controller.h>
+
+extern zuluide::status::StatusController g_StatusController;
+extern zuluide::status::SystemStatus g_previous_controller_status;
 
 // Map from command index for command name for logging
 static const char *get_atapi_command_name(uint8_t cmd)
@@ -362,7 +366,7 @@ bool IDEATAPIDevice::set_device_signature(uint8_t error, bool was_reset)
         // Command complete
         if (error == IDE_ERROR_ABORT)
             ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_ERR);
-        else 
+        else
             ide_phy_assert_irq(IDE_STATUS_DEVRDY);
 
     }
@@ -782,17 +786,16 @@ bool IDEATAPIDevice::atapi_cmd_ok()
 
 bool IDEATAPIDevice::atapi_test_unit_ready(const uint8_t *cmd)
 {
-    if (!has_image())
-    {
-        return atapi_cmd_not_ready_error();
-    }
-
     if (m_devinfo.removable && m_removable.ejected)
     {
         if (m_removable.reinsert_media_after_eject)
         {
-            insert_media();
+            insert_next_media(m_image);
         }
+        // return atapi_cmd_not_ready_error();
+    }
+    else if (!has_image())
+    {
         return atapi_cmd_not_ready_error();
     }
 
@@ -826,7 +829,7 @@ bool IDEATAPIDevice::atapi_start_stop_unit(const uint8_t *cmd)
         // Load condition
         else
         {
-            insert_media();
+            insert_next_media(m_image);
         }
     }
     return atapi_cmd_ok();
@@ -869,7 +872,7 @@ bool IDEATAPIDevice::atapi_inquiry(const uint8_t *cmd)
 
     if (m_removable.reinsert_media_on_inquiry)
     {
-        insert_media();
+        insert_next_media(m_image);
     }
 
     return atapi_cmd_ok();
@@ -1320,7 +1323,7 @@ void IDEATAPIDevice::eject_button_poll(bool immediate)
             //m_atapi_state.unit_attention = true;
             dbgmsg("Ejection button pressed");
             if (m_removable.ejected)
-                insert_media();
+                insert_next_media(m_image);
             else
             {
                 button_eject_media();
@@ -1346,54 +1349,73 @@ void IDEATAPIDevice::eject_media()
 
 void IDEATAPIDevice::insert_media(IDEImage *image)
 {
-    zuluide::images::ImageIterator img_iterator;
-    char filename[MAX_FILE_PATH+1];
-
     if (m_devinfo.removable)
     {
-        if (image != nullptr)
-        {
-            set_image(image);
-            m_removable.ejected = false;
-            m_atapi_state.not_ready = true;
-        }
-        else if (m_removable.ejected)
-        {
-            img_iterator.Reset();
-            if (!img_iterator.IsEmpty())
-            {
-                if (m_image)
-                {
-                    m_image->get_filename(filename, sizeof(filename));
-                    if (!img_iterator.MoveToFile(filename))
-                    {
-                        img_iterator.MoveNext();
-                    }
-                }
-                else
-                {
-                    img_iterator.MoveNext();
-                }
+        zuluide::images::ImageIterator img_iterator;
+        char filename[MAX_FILE_PATH+1];
 
-                if (img_iterator.IsLast())
-                {
-                    img_iterator.MoveFirst();
-                }
-                else
+        img_iterator.Reset();
+        if (!img_iterator.IsEmpty())
+        {
+            if (image && image->get_image_name(filename, sizeof(filename)))
+            {
+                if (!img_iterator.MoveToFile(filename))
+                    img_iterator.MoveNext();
+            }
+            else
+                img_iterator.MoveNext();
+
+            g_ide_imagefile.clear();
+            if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str(), true))
+            {
+                logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
+                m_removable.ejected = false;
+                set_image(&g_ide_imagefile);
+            }
+        }
+        img_iterator.Cleanup();
+    }
+}
+
+void IDEATAPIDevice::insert_next_media(IDEImage *image)
+{
+    zuluide::images::ImageIterator img_iterator;
+    char filename[MAX_FILE_PATH+1];
+    if (m_devinfo.removable && m_removable.ejected)
+    {
+        img_iterator.Reset();
+        if (!img_iterator.IsEmpty())
+        {
+            if (image && image->get_image_name(filename, sizeof(filename)))
+            {
+                if (!img_iterator.MoveToFile(filename))
                 {
                     img_iterator.MoveNext();
-                }
-                g_ide_imagefile.clear();
-                if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str(), false))
-                {
-                    set_image(&g_ide_imagefile);
-                    logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
-                    m_removable.ejected = false;
-                    m_atapi_state.not_ready = true;
                 }
             }
-            img_iterator.Cleanup();
+            else
+            {
+                img_iterator.MoveNext();
+            }
+
+            if (img_iterator.IsLast())
+            {
+                img_iterator.MoveFirst();
+            }
+            else
+            {
+                img_iterator.MoveNext();
+            }
+
+            g_ide_imagefile.clear();
+            if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str(), true))
+            {
+                m_removable.ejected = false;
+                g_StatusController.LoadImage(img_iterator.Get());
+                g_previous_controller_status = g_StatusController.GetStatus();
+            }
         }
+        img_iterator.Cleanup();
     }
 }
 
@@ -1403,7 +1425,7 @@ void IDEATAPIDevice::sd_card_inserted()
         && m_removable.reinsert_media_after_sd_insert
         && m_removable.ejected)
     {
-        insert_media();
+        insert_next_media(m_image);
     }
 }
 

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -1349,7 +1349,7 @@ void IDEATAPIDevice::button_eject_media()
 void IDEATAPIDevice::eject_media()
 {
     char filename[MAX_FILE_PATH+1];
-    m_image->get_filename(filename, sizeof(filename));
+    m_image->get_image_name(filename, sizeof(filename));
     logmsg("Device ejecting media: \"", filename, "\"");
     m_removable.ejected = true;
 }
@@ -1373,11 +1373,13 @@ void IDEATAPIDevice::insert_media(IDEImage *image)
                 img_iterator.MoveNext();
 
             g_ide_imagefile.clear();
-            if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str(), true))
+            if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str()))
             {
                 logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
                 m_removable.ejected = false;
                 set_image(&g_ide_imagefile);
+                m_atapi_state.unit_attention = true;
+                m_atapi_state.sense_asc = ATAPI_ASC_MEDIUM_CHANGE;
                 set_not_ready(true);
             }
         }

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -66,7 +66,9 @@ public:
 
     virtual void eject_media();
 
-    virtual void insert_media(IDEImage *image = nullptr);
+    virtual void insert_media(IDEImage *image = nullptr) override;
+
+    virtual void insert_next_media(IDEImage *image = nullptr) override;
 
     virtual void sd_card_inserted() override;
 

--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -46,6 +46,7 @@
 #endif
 
 extern zuluide::status::StatusController g_StatusController;
+extern zuluide::status::SystemStatus g_previous_controller_status;
 
 static const uint8_t DiscInformation[] =
 {
@@ -293,7 +294,7 @@ void IDECDROMDevice::initialize(int devidx)
 #endif // ENABLE_AUDIO_OUTPUT
 }
 
-void IDECDROMDevice::reset() 
+void IDECDROMDevice::reset()
 {
     IDEATAPIDevice::reset();
     set_esn_event(esn_event_t::NoChange);
@@ -350,7 +351,7 @@ void IDECDROMDevice::set_image(IDEImage *image)
             image = nullptr;
         }
 #ifdef ENABLE_AUDIO_OUTPUT
-        else 
+        else
             audio_set_cue_parser(&m_cueparser, folder);
 #endif // ENABLE_AUDIO_OUTPUT
     }
@@ -721,14 +722,14 @@ bool IDECDROMDevice::atapi_get_event_status_notification(const uint8_t *cmd)
         buf[4] = 0x02; // Operational state has changed
         buf[5] = 0x00; // Power status
         buf[6] = 0x00; // Start slot
-        buf[7] = 0x01; // End slot 
+        buf[7] = 0x01; // End slot
         esn_next_event();
     }
     // Media class request
     else if (cmd[4] & 0x10)
     {
-        if (m_esn.request == IDECDROMDevice::esn_class_request_t::Media && 
-            (   
+        if (m_esn.request == IDECDROMDevice::esn_class_request_t::Media &&
+            (
                 m_esn.event == esn_event_t::MNewMedia
                 || m_esn.event == esn_event_t::MEjectRequest
                 || m_esn.event == esn_event_t::MMediaRemoval
@@ -746,7 +747,7 @@ bool IDECDROMDevice::atapi_get_event_status_notification(const uint8_t *cmd)
                 buf[1] = 6; // EventDataLength
                 buf[2] = m_esn.request; // Media status events
                 buf[3] = 0x12; // Supported events
-                if (m_esn.current_event == esn_event_t::MEjectRequest) 
+                if (m_esn.current_event == esn_event_t::MEjectRequest)
                     buf[4] = 0x01; // Eject Request
                 else if (m_esn.current_event == esn_event_t::MNewMedia)
                     buf[4] = 0x02; // New Media
@@ -776,7 +777,7 @@ bool IDECDROMDevice::atapi_get_event_status_notification(const uint8_t *cmd)
             }
         }
         // output media no change
-        else 
+        else
         {
             // Report media status events
             buf[0] = 0;
@@ -1561,7 +1562,7 @@ void IDECDROMDevice::eject_media()
     audio_stop();
 #endif
     char filename[MAX_FILE_PATH+1];
-    m_image->get_filename(filename, sizeof(filename));
+    m_image->get_image_name(filename, sizeof(filename));
     logmsg("Device ejecting media: \"", filename, "\"");
     set_esn_event(esn_event_t::NoChange);
     m_removable.ejected = true;
@@ -1581,55 +1582,75 @@ void IDECDROMDevice::insert_media(IDEImage *image)
 #endif
     zuluide::images::ImageIterator img_iterator;
     char filename[MAX_FILE_PATH+1];
-    if (m_devinfo.removable) 
-    {
-        if (image != nullptr)
-        {
-            set_image(image);
-            set_esn_event(esn_event_t::MNewMedia);
-            m_removable.ejected = false;
-            m_atapi_state.not_ready = true;
-        }
-        else if (m_removable.ejected)
-        {
-            img_iterator.Reset();
-            if (!img_iterator.IsEmpty())
-            {
-                if (m_image)
-                {
-                    m_image->get_filename(filename, sizeof(filename));
-                    if (!img_iterator.MoveToFile(filename))
-                    {
-                        img_iterator.MoveNext();
-                    }
-                }
-                else
-                {
-                    img_iterator.MoveNext();
-                }
 
-                if (img_iterator.IsLast())
-                {
-                    img_iterator.MoveFirst();
-                }
-                else
-                {
-                    img_iterator.MoveNext();
-                }
-            
-                g_ide_imagefile.clear();
-                if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str(), true))
-                {
-                    set_image(&g_ide_imagefile);
-                    logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
-                    set_esn_event(esn_event_t::MNewMedia);
-                    m_removable.ejected = false;
-                    m_atapi_state.not_ready = true;
-                }
-            }
-            img_iterator.Cleanup();
+    img_iterator.Reset();
+    if (!img_iterator.IsEmpty())
+    {
+        if (image && image->get_image_name(filename, sizeof(filename)))
+        {
+            if (!img_iterator.MoveToFile(filename))
+                img_iterator.MoveNext();
+        }
+        else
+            img_iterator.MoveNext();
+
+        g_ide_imagefile.clear();
+        if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str(), true))
+        {
+            logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
+            m_removable.ejected = false;
+            set_image(&g_ide_imagefile);
+            set_esn_event(esn_event_t::MNewMedia);
         }
     }
+    img_iterator.Cleanup();
+}
+
+void IDECDROMDevice::insert_next_media(IDEImage *image)
+{
+#if ENABLE_AUDIO_OUTPUT
+    audio_stop();
+#endif
+    zuluide::images::ImageIterator img_iterator;
+    char filename[MAX_FILE_PATH+1];
+    if (m_devinfo.removable && m_removable.ejected)
+    {
+        img_iterator.Reset();
+        if (!img_iterator.IsEmpty())
+        {
+            if (image && image->get_image_name(filename, sizeof(filename)))
+            {
+                if (!img_iterator.MoveToFile(filename))
+                {
+                    img_iterator.MoveNext();
+                }
+            }
+            else
+            {
+                img_iterator.MoveNext();
+            }
+
+            if (img_iterator.IsLast())
+            {
+                img_iterator.MoveFirst();
+            }
+            else
+            {
+                img_iterator.MoveNext();
+            }
+
+            g_ide_imagefile.clear();
+            if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str(), true))
+            {
+                m_removable.ejected = false;
+                g_previous_controller_status = g_StatusController.GetStatus();
+                g_StatusController.LoadImage(img_iterator.Get());
+                set_esn_event(esn_event_t::MNewMedia);
+            }
+        }
+        img_iterator.Cleanup();
+    }
+
 }
 
 void IDECDROMDevice::set_esn_event(esn_event_t event)
@@ -1767,8 +1788,8 @@ size_t IDECDROMDevice::atapi_get_configuration(uint8_t return_type, uint16_t fea
 
 #ifdef ENABLE_AUDIO_OUTPUT
     // CD audio feature (0x103, 259)
-    if (feature == ATAPI_FEATURE_CDAUDIO 
-        && (return_type == ATAPI_RT_SINGLE 
+    if (feature == ATAPI_FEATURE_CDAUDIO
+        && (return_type == ATAPI_RT_SINGLE
             || return_type == ATAPI_RT_ALL
             || (return_type == ATAPI_RT_ALL_CURRENT && !m_removable.ejected)))
     {

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -43,6 +43,8 @@ public:
     virtual void button_eject_media() override;
 
     virtual void insert_media(IDEImage *image = nullptr) override;
+
+    virtual void insert_next_media(IDEImage *image = nullptr) override;
     
     // esn - event status notification
     enum class esn_event_t 

--- a/src/ide_imagefile.cpp
+++ b/src/ide_imagefile.cpp
@@ -139,6 +139,14 @@ bool IDEImageFile::get_filename(char *buf, size_t buflen)
     }
 }
 
+bool IDEImageFile::get_image_name(char *buf, size_t buflen)
+{
+    if (is_folder())
+        return get_foldername(buf, buflen);
+    else
+        return get_filename(buf, buflen);
+}
+
 bool IDEImageFile::is_folder()
 {
     return m_is_folder;

--- a/src/ide_imagefile.h
+++ b/src/ide_imagefile.h
@@ -50,6 +50,9 @@ public:
     // Return filename or false if not file-backed
     virtual bool get_filename(char *buf, size_t buflen) = 0;
 
+    // Get the filename or folder name of the image depending on is_folder
+    virtual bool get_image_name(char *buf, size_t buflen) = 0;
+
     // Return image size in bytes
     virtual uint64_t capacity() = 0;
 
@@ -108,6 +111,7 @@ public:
     void close();
 
     virtual bool get_filename(char *buf, size_t buflen);
+    virtual bool get_image_name(char *buf, size_t buflen);
     virtual uint64_t capacity();
     virtual uint64_t file_position();
     virtual bool is_open();

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -73,8 +73,11 @@ public:
     // Called when an SD card is reinserted
     virtual void sd_card_inserted() = 0;
 
-    // For removable media devices
+    // For removable media devices - insert current
     virtual void insert_media(IDEImage *image = nullptr) = 0;
+
+    // For removable media devices - insert next
+    virtual void insert_next_media(IDEImage *image = nullptr) = 0;
 
 
 protected:

--- a/src/ide_removable.cpp
+++ b/src/ide_removable.cpp
@@ -60,7 +60,7 @@ void IDERemovable::set_image(IDEImage *image)
     if (image)
     {
         char filename[MAX_FILE_PATH] = "";
-        image->get_filename(filename, sizeof(filename));
+        image->get_image_name(filename, sizeof(filename));
 
         if (image->capacity() % REMOVABLE_SECTORSIZE != 0)
         {

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -66,6 +66,8 @@ public:
 
     virtual void insert_media(IDEImage *image = nullptr) {;}
 
+    virtual void insert_next_media(IDEImage *image = nullptr) {;}
+
 protected:
     IDEImage *m_image;
 

--- a/src/ide_zipdrive.cpp
+++ b/src/ide_zipdrive.cpp
@@ -452,7 +452,7 @@ bool IDEZipDrive::atapi_inquiry(const uint8_t *cmd)
 
     if (m_removable.reinsert_media_on_inquiry)
     {
-        insert_media();
+        insert_next_media(m_image);
     }
 
     return atapi_cmd_ok();

--- a/src/ide_zipdrive.cpp
+++ b/src/ide_zipdrive.cpp
@@ -123,8 +123,8 @@ void IDEZipDrive::set_image(IDEImage *image)
 {
     if (image)
     {
-        char filename[MAX_FILE_PATH] = "";
-        image->get_filename(filename, sizeof(filename));
+        char filename[MAX_FILE_PATH + 1] = {0};
+        image->get_image_name(filename, sizeof(filename));
         uint64_t actual_size = image->capacity();
         uint64_t expected_size = ZIP100_SECTORSIZE * ZIP100_SECTORCOUNT;
         // use filename for Zip disk serial string

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -27,6 +27,7 @@
 # reinsert_media_after_eject = 1 # Automatically reinsert media after eject
 # reinsert_media_on_inquiry = 1  # Automaitcally reinsert media on inquiry command
 # reinsert_media_on_sd_insert = 0 # Set to 1 to reinsert media when the SD card is inserted after eject
+# init_with_last_used_image = 1 # Enabled by default, initialize with the last image used before power off
 
 # ignore_command_interrupt = 1 # Ignore a new command interrupting the current one
 # atapi_intrq = 1 # enables the INTRQ signal during a PACKET cmd, some systems need it disabled, default enabled. See documentation for specifics


### PR DESCRIPTION
When switching between CD-ROM images with the ZuluIDE, a file `zululast.txt` will be created keeping track of the last image used. On initialization, ZuluIDE will load the file listed in `zululast.txt` if it can find it.

Also fixed the issue where changing images by using the OS to eject a CD would not update the control board display. Now it will.