### PR TITLE
Fix multi-bin file audio playback stutter

### DIFF
--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -1738,17 +1738,16 @@ CUETrackInfo IDECDROMDevice::getTrackFromLBA(uint32_t lba)
     }
     else
     {
-        FsFile last_track_file = SD.open(m_cached_track_result.filename, O_RDONLY);
-        if (last_track_file.isOpen())
+
+        if (selectBinFileForTrack(&m_cached_track_result))
         {
-            uint64_t filesize = last_track_file.size();
+            uint64_t filesize = m_image->capacity();
             if (m_cached_track_result.file_offset <= filesize)
             {
                 m_cached_end_lba =  ((filesize - m_cached_track_result.file_offset) / m_cached_track_result.sector_length)
                                     + m_cached_track_result.data_start;
             }
         }
-        last_track_file.close();
     }
     return result;
 }

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -118,6 +118,11 @@ protected:
     bool getFirstLastTrackInfo(CUETrackInfo &first, CUETrackInfo &last);
     uint32_t getLeadOutLBA(const CUETrackInfo* lasttrack);
     CUETrackInfo getTrackFromLBA(uint32_t lba);
+    void clear_cached_track_info();
+    CUETrackInfo m_cached_track_result;
+    uint32_t m_cached_end_lba;
+
+
 
     // If the .cue file has data split across multiple files,
     // this function will reopen m_imagefile when track is changed.


### PR DESCRIPTION
`getTrackFromLBA` was parsing the whole cue file whenever it was called. This caches the current track and the ending LBA of the track. If it is called during audio playback and the LBA is still within the track, the cached track info is returned.

The cache is cleared when set_file is called.

Should fix issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/123
