### PR TITLE
Increase max .cue size to 4096 bytes

### DIFF
--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -27,7 +27,7 @@
 #include <ZuluIDE_config.h>
 #include <CUEParser.h>
 
-#define MAX_CUE_SHEET_SIZE 1024
+#define MAX_CUE_SHEET_SIZE 4096
 
 namespace zuluide::images {
 

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -112,7 +112,7 @@ protected:
     virtual ssize_t read_callback(const uint8_t *data, size_t blocksize, size_t num_blocks);
 
     // Access data from CUE sheet, or dummy data if no cue sheet provided
-    char m_cuesheet[1024];
+    char m_cuesheet[4096];
     CUEParser m_cueparser;
     bool loadAndValidateCueSheet(FsFile *dir, const char *cuesheetname);
     bool getFirstLastTrackInfo(CUETrackInfo &first, CUETrackInfo &last);


### PR DESCRIPTION
I've encountered a number of images where the .cue is larger than 1024 bytes. It's sometimes possible to manually edit the cue and rename the files to within that limit, but not always.

The largest example in my personal collection is [redump: Half-Life (USA) (Game of the Year Edition)](http://redump.org/disc/26001/):
- [original cue: 3772 bytes](https://github.com/user-attachments/files/17735814/Half-Life.USA.Game.of.the.Year.Edition.cue.txt)
- [edited cue: 2332 bytes](https://github.com/user-attachments/files/17735816/Half-Life.USA.Game.of.the.Year.Edition._small.cue.txt)

I've tested this increase to 4096 bytes and am not seeing any issues. This allows me to use all the .cue files in my collection as is (distribution below).
| Bucket (<= bytes) | # .cue Files |
| --- | --- |
| 1024 | 1090 |
| 2048 | 108 |
| 3192 | 38 |
| 4096 | 12 |

---

There are definitely larger cuesheets out there as [redump.org cuesheet downloads](http://redump.org/downloads/) have some (largest is 40kb). This max should probably be reevaluated in the future.