### PR TITLE
Fix Zip Drive inquiry product string

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -870,9 +870,9 @@ bool IDEATAPIDevice::atapi_inquiry(const uint8_t *cmd)
     inquiry[ATAPI_INQUIRY_REMOVABLE_MEDIA] = m_devinfo.removable ? 0x80 : 0;
     inquiry[ATAPI_INQUIRY_ATAPI_VERSION] = 0x21;
     inquiry[ATAPI_INQUIRY_EXTRA_LENGTH] = count - 5;
-    strncpy((char*)&inquiry[ATAPI_INQUIRY_VENDOR], m_devinfo.atapi_vendor, 8);
-    strncpy((char*)&inquiry[ATAPI_INQUIRY_PRODUCT], m_devinfo.atapi_product, 16);
-    strncpy((char*)&inquiry[ATAPI_INQUIRY_REVISION], m_devinfo.atapi_version, 4);
+    memcpy(&inquiry[ATAPI_INQUIRY_VENDOR], m_devinfo.atapi_vendor, 8);
+    memcpy(&inquiry[ATAPI_INQUIRY_PRODUCT], m_devinfo.atapi_product, 16);
+    memcpy(&inquiry[ATAPI_INQUIRY_REVISION], m_devinfo.atapi_version, 4);
 
     if (req_bytes < count) count = req_bytes;
     atapi_send_data(inquiry, count);
@@ -1444,17 +1444,23 @@ void IDEATAPIDevice::set_inquiry_strings(const char* default_vendor, const char*
     char input_str[17];
     uint8_t input_len;
 
-    memset(input_str, ' ', 16);
+    memset(input_str, '\0', 17);
     input_len = ini_gets("IDE", "atapi_product", default_product, input_str, 17, CONFIGFILE);
+    if (input_len > 16) input_len = 16;
     memcpy(m_devinfo.atapi_product, input_str, input_len);
+    formatDriveInfoField(m_devinfo.atapi_product, 16, false);
 
-    memset(input_str, ' ', 8);
+    memset(input_str, '\0', 9);
     input_len = ini_gets("IDE","atapi_vendor", default_vendor, input_str, 9, CONFIGFILE);
+    if (input_len > 8) input_len = 8;
     memcpy(m_devinfo.atapi_vendor, input_str, input_len);
+    formatDriveInfoField(m_devinfo.atapi_vendor, 8, false);
 
-    memset(input_str, ' ', 4);
+    memset(input_str, '\0', 5);
     input_len = ini_gets("IDE","atapi_version", default_version, input_str, 5, CONFIGFILE);
+    if (input_len > 16) input_len = 4;
     memcpy(m_devinfo.atapi_version, input_str, input_len);
+    formatDriveInfoField(m_devinfo.atapi_version, 4, false);
 }
 
 void IDEATAPIDevice::set_not_ready(bool not_ready)

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -470,19 +470,19 @@ void IDEDevice::set_ident_strings(const char* default_model, const char* default
     char input_str[41];
     uint16_t input_len;
 
-    memset(m_devconfig.ata_model, '\0', 41);
+    memset(input_str, '\0', 41);
     input_len = ini_gets("IDE", "ide_model", default_model, input_str, 41, CONFIGFILE);
     if (input_len > 40) input_len = 40;
     memcpy(m_devconfig.ata_model, input_str, input_len);
     formatDriveInfoField(m_devconfig.ata_model, 40, false);
 
-    memset(m_devconfig.ata_serial, '\0', 21);
+    memset(input_str, '\0', 21);
     input_len = ini_gets("IDE","ide_serial", default_serial, input_str, 21, CONFIGFILE);
     if (input_len > 20) input_len = 20;
     memcpy(m_devconfig.ata_serial, input_str, input_len);
     formatDriveInfoField(m_devconfig.ata_serial, 20, false);
 
-    memset(m_devconfig.ata_revision, '\0', 9);
+    memset(input_str, '\0', 9);
     input_len = ini_gets("IDE","ide_revision", default_revision, input_str, 9, CONFIGFILE);
     if (input_len > 8) input_len = 8;
     memcpy(m_devconfig.ata_revision, input_str, input_len);

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -95,7 +95,7 @@ protected:
 
     // PHY capabilities limited by active device configuration
     ide_phy_capabilities_t m_phy_caps;
-
+    void formatDriveInfoField(char *field, int fieldsize, bool align_right);
     void set_ident_strings(const char* default_model, const char* default_serial, const char* default_revision);
 };
 

--- a/src/ide_zipdrive.cpp
+++ b/src/ide_zipdrive.cpp
@@ -351,12 +351,9 @@ bool IDEZipDrive::atapi_inquiry(const uint8_t *cmd)
         inquiry[5] = 0x00;
         inquiry[6] = 0x00;
         inquiry[7] = 0x00;
-        // Vendor ID
-        memcpy(inquiry + 8, m_devinfo.atapi_vendor, sizeof(m_devinfo.atapi_vendor));
-        // Product ID
-        memcpy(inquiry + 15, m_devinfo.atapi_product, sizeof(m_devinfo.atapi_product));
-        // Product Revision
-        memcpy(inquiry + 32, m_devinfo.atapi_version, sizeof(m_devinfo.atapi_version));
+        memcpy(&inquiry[ATAPI_INQUIRY_VENDOR], m_devinfo.atapi_vendor, 8);
+        memcpy(&inquiry[ATAPI_INQUIRY_PRODUCT], m_devinfo.atapi_product, 16);
+        memcpy(&inquiry[ATAPI_INQUIRY_REVISION], m_devinfo.atapi_version, 4);
         // vendor specific data
         inquiry[36] = 0x30;
         inquiry[37] = 0x39;
@@ -404,13 +401,9 @@ bool IDEZipDrive::atapi_inquiry(const uint8_t *cmd)
         inquiry[1]   = 0x80;
         inquiry[3]   = 0x01;
         inquiry[4]   = 0x75;
-        // Vendor ID
-        memcpy(inquiry + 8, m_devinfo.atapi_vendor, sizeof(m_devinfo.atapi_vendor));
-        // Product ID
-        memcpy(inquiry + 15, m_devinfo.atapi_product, sizeof(m_devinfo.atapi_product));
-        // Product Revision
-        memcpy(inquiry + 32, m_devinfo.atapi_version, sizeof(m_devinfo.atapi_version));
-        // vendor specific data
+        memcpy(&inquiry[ATAPI_INQUIRY_VENDOR], m_devinfo.atapi_vendor, 8);
+        memcpy(&inquiry[ATAPI_INQUIRY_PRODUCT], m_devinfo.atapi_product, 16);
+        memcpy(&inquiry[ATAPI_INQUIRY_REVISION], m_devinfo.atapi_version, 4);
         inquiry[36]  = 0x30;
         inquiry[37]  = 0x38;
         inquiry[38]  = 0x2F;


### PR DESCRIPTION
The inquiry string was being written at the wrong offset. Fixed it plus made sure the inquiry product, vendor, and version strings were all properly padded with spaces. Did the same with the equivalent ATA strings.