### PR TITLE
Enable debug via a flag in the zuluide.ini file

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -593,6 +593,7 @@ void zuluide_main_loop(void)
         if (g_sdcard_present)
         {
             logmsg("SD card reinit succeeded");
+            g_log_debug = ini_getbool("IDE", "debug", 0, CONFIGFILE);
             print_sd_info();
 
             init_logfile();

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -498,7 +498,8 @@ static void zuluide_setup_sd_card()
         if (g_sdcard_present)
         {
             init_logfile();
-
+            g_log_debug = ini_getbool("IDE", "debug", g_log_debug, CONFIGFILE);
+            dbgmsg("Enabling debug via ", CONFIGFILE, " setting");
             if (ini_getbool("IDE", "DisableStatusLED", false, CONFIGFILE))
             {
                 platform_disable_led();
@@ -593,7 +594,8 @@ void zuluide_main_loop(void)
         if (g_sdcard_present)
         {
             logmsg("SD card reinit succeeded");
-            g_log_debug = ini_getbool("IDE", "debug", 0, CONFIGFILE);
+            g_log_debug = ini_getbool("IDE", "debug", g_log_debug, CONFIGFILE);
+            dbgmsg("Enabling debug via ", CONFIGFILE, " setting after SD card reinit");
             print_sd_info();
 
             init_logfile();

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,8 +27,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2024.11.13"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2024.11.22"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -135,6 +135,8 @@ void ide_protocol_init(IDEDevice *primary, IDEDevice *secondary)
 
     do_phy_reset();
     g_ide_reset_after_init_done = false;
+
+
 }
 
 
@@ -495,6 +497,8 @@ void IDEDevice::initialize(int devidx)
     memset(&m_devconfig, 0, sizeof(m_devconfig));
 
     m_devconfig.dev_index = devidx;
+
+    g_log_debug = ini_getbool("IDE", "debug", 0, CONFIGFILE);
 
     m_phy_caps = *ide_phy_get_capabilities();
     m_devconfig.max_pio_mode = ini_getl("IDE", "max_pio", 3, CONFIGFILE);

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -498,8 +498,6 @@ void IDEDevice::initialize(int devidx)
 
     m_devconfig.dev_index = devidx;
 
-    g_log_debug = ini_getbool("IDE", "debug", 0, CONFIGFILE);
-
     m_phy_caps = *ide_phy_get_capabilities();
     m_devconfig.max_pio_mode = ini_getl("IDE", "max_pio", 3, CONFIGFILE);
     m_devconfig.max_udma_mode = ini_getl("IDE", "max_udma", 0, CONFIGFILE);

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -1,6 +1,8 @@
 [IDE]
 # All ZuluIDE ini file parameters are optional, and the default settings will work in most scenarios.
 
+# debug = 0 # set to 1 to enable debug messaging
+
 # enable_usb_mass_storage = 0 # Disabled by default, set to 1 to enable access via USB mass storage
 
 # eject_button = 0 # bit field bit 0 = GPIO_11,  bit 1 = GPIO_14


### PR DESCRIPTION
This enables debug logging when `debug = 1` is set in the `zuluide.ini` file. It is first checked in the board initialization function and also checked after an SD card is inserted.