### PR TITLE
Fix cuesheet read buffer

### DIFF
--- a/lib/ZuluControl/src/images/image_iterator.cpp
+++ b/lib/ZuluControl/src/images/image_iterator.cpp
@@ -383,7 +383,13 @@ bool tryReadQueueSheet(FsFile &cuesheetfile, char* cuesheet) {
     return false;
   }
 
-  cuesheetfile.read(cuesheet, MAX_CUE_SHEET_SIZE);
+  auto bytesread = cuesheetfile.read(cuesheet, MAX_CUE_SHEET_SIZE);
+  if (bytesread < 0) {
+    logmsg("---- Failed to read CUE sheet");
+    return false;
+  } else if (bytesread < MAX_CUE_SHEET_SIZE) {
+    cuesheet[bytesread+1] = 0;
+  }
   return true;
 }
 
@@ -418,6 +424,8 @@ bool ImageIterator::FetchSizeFromCueFile() {
     file.close();
     return false;
   }
+  char dirname[MAX_FILE_PATH + 1];
+  currentFile.getName(dirname, sizeof(dirname));
   
   CUEParser parser(cuesheet);
   parser.restart();
@@ -434,6 +442,7 @@ bool ImageIterator::FetchSizeFromCueFile() {
         trackFile.close();
         currentfilename = current->filename;
       } else {
+        logmsg("Failed to read \"", dirname, "/", current->filename, "\"");
         // If we cannot open a track file, we cannot proceed in a meaningful way.
         return false;
       }


### PR DESCRIPTION
`FetchSizeFromCueFile` was failing due to attempting to read a filename from the wrong parent directory. This was caused by a previous invocation's read into `cuesheet` carrying over. Ex. 

- load `a/a.cue` with size of 64 bytes
- successfully read `a/a*.bin` files 
- load `b/b.cue` with size of 48 bytes
- successfully read `b/b*.bin` files
- fail to read `b/a*.bin` files which carried in bytes 48:64 from the load of `a/a.cue` 