### PR TITLE
Improve rigid disc support

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -344,11 +344,6 @@ void setupStatusController()
     break;
   }
 
-  if (isPrimary)
-      ide_protocol_init(g_ide_device, NULL); // Primary device
-  else
-      ide_protocol_init(NULL, g_ide_device); // Secondary device
-
   if (device) {
     g_StatusController.SetIsPrimary(isPrimary);
     g_StatusController.UpdateDeviceStatus(std::move(device));
@@ -378,6 +373,11 @@ void setupStatusController()
   }
 
   loadFirstImage();
+
+  if (isPrimary)
+    ide_protocol_init(g_ide_device, NULL); // Primary device
+  else
+    ide_protocol_init(NULL, g_ide_device); // Secondary device
 }
 
 void loadFirstImage() {

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -74,6 +74,8 @@ void IDEATAPIDevice::set_image(IDEImage *image)
 
 bool IDEATAPIDevice::handle_command(ide_registers_t *regs)
 {
+    delay(m_devconfig.access_delay);
+
     switch (regs->command)
     {
         // Commands superseded by the ATAPI packet interface

--- a/src/ide_imagefile.cpp
+++ b/src/ide_imagefile.cpp
@@ -101,6 +101,7 @@ bool IDEImageFile::internal_open(const char *filename)
     }
 
     m_capacity = m_file.size();
+    dbgmsg("Image file ", filename, " size ", (int)m_capacity);
 
     uint32_t begin = 0, end = 0;
     if (m_file.contiguousRange(&begin, &end))

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -223,6 +223,10 @@ void ide_protocol_poll()
             //     ide_phy_set_regs(&regs);
             //     ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_ERR);
             // }
+            else if (regs.error)
+            {
+                logmsg("-- Command ", get_ide_command_name(cmd), " completed with error status ", regs.error);
+            }
             else
             {
                 dbgmsg("-- Command complete");
@@ -504,6 +508,10 @@ void IDEDevice::initialize(int devidx)
     logmsg("-- Max PIO mode: ", m_devconfig.max_pio_mode, " (phy max ", m_phy_caps.max_pio_mode, ")");
     logmsg("-- Max UDMA mode: ", m_devconfig.max_udma_mode, " (phy max ", m_phy_caps.max_udma_mode, ")");
     logmsg("-- Max blocksize: ", m_devconfig.max_blocksize, " (phy max ", (int)m_phy_caps.max_blocksize, ")");
+    m_devconfig.ide_sectors = ini_getl("IDE", "sectors", 0, CONFIGFILE);
+    m_devconfig.ide_heads = ini_getl("IDE", "heads", 0, CONFIGFILE);
+    m_devconfig.ide_cylinders = ini_getl("IDE", "cylinders", 0, CONFIGFILE);
+    m_devconfig.access_delay = ini_getl("IDE", "access_delay", 0, CONFIGFILE);
 
     g_ignore_cmd_interrupt = ini_getl("IDE", "ignore_command_interrupt", 1, CONFIGFILE);
     if (!g_ignore_cmd_interrupt)

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -90,7 +90,10 @@ protected:
         char ata_model[40];
         char ata_revision[8];
         char ata_serial[20];
-
+        int ide_cylinders;
+        int ide_heads;
+        int ide_sectors;
+        int access_delay;
     } m_devconfig;
 
     // PHY capabilities limited by active device configuration

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -119,7 +119,7 @@ protected:
     // IDE command handlers
     virtual bool cmd_nop(ide_registers_t *regs);
     virtual bool cmd_set_features(ide_registers_t *regs);
-    virtual bool cmd_read(ide_registers_t *regs, bool dma_transfer);
+    virtual bool cmd_read(ide_registers_t *regs, bool dma_transfer, bool verify_only);
     virtual bool cmd_write(ide_registers_t *regs, bool dma_transfer);
     virtual bool cmd_read_buffer(ide_registers_t *regs);
     virtual bool cmd_write_buffer(ide_registers_t *regs);

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -35,6 +35,11 @@
 # ignore_command_interrupt = 1 # Ignore a new command interrupting the current one
 # atapi_intrq = 1 # enables the INTRQ signal during a PACKET cmd, some systems need it disabled, default enabled. See documentation for specifics
 
+# cylinders = 1024   # Override C/H/S for harddrives.
+# heads = 16         # All three must be specified, otherwise automatic guess is used.
+# sectors = 63
+
+# access_delay = 0   # Add extra delay (milliseconds) before answering to commands
 
 [UI]
 # An additional Pico W is required to utilize this experimental functionality, which is not yet generally available.


### PR DESCRIPTION
- Fix automatic initialization of C/H/S parameters (image file was loaded too late)
- Add config options sectors/heads/cylinders for rigid disc
- Add option access_delay for hosts that don't like too fast responses
- Add support for command IDE_CMD_READ_VERIFY_SECTORS

Based on patch submitted by Dominik Behr.