### PR TITLE
Fix referenced nullptr in the eject method

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -1350,9 +1350,16 @@ void IDEATAPIDevice::button_eject_media()
 
 void IDEATAPIDevice::eject_media()
 {
-    char filename[MAX_FILE_PATH+1];
-    m_image->get_image_name(filename, sizeof(filename));
-    logmsg("Device ejecting media: \"", filename, "\"");
+    if (m_image)
+    {
+        char filename[MAX_FILE_PATH+1];
+        m_image->get_image_name(filename, sizeof(filename));
+        logmsg("Device ejecting media: \"", filename, "\"");
+    }
+    else
+    {
+        logmsg("Device ejecting media, image already cleared");
+    }
     m_removable.ejected = true;
 }
 

--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -1572,12 +1572,18 @@ void IDECDROMDevice::eject_media()
 #if ENABLE_AUDIO_OUTPUT
     audio_stop();
 #endif
-    char filename[MAX_FILE_PATH+1];
-    m_image->get_image_name(filename, sizeof(filename));
-    logmsg("Device ejecting media: \"", filename, "\"");
+    if (m_image)
+    {
+        char filename[MAX_FILE_PATH+1];
+        m_image->get_image_name(filename, sizeof(filename));
+        logmsg("Device ejecting media: \"", filename, "\"");
+    }
+    else
+    {
+        logmsg("Device ejecting media, image already cleared");
+    }
     set_esn_event(esn_event_t::NoChange);
     m_removable.ejected = true;
-
 }
 
 void IDECDROMDevice::button_eject_media()


### PR DESCRIPTION
The member variable `m_image` can be a nullptr. For example when an image is ejected via the I2C controller board, this will clear m_image. If eject method gets run after this, the attempt to get the filename for the eject message hits a hard fault. This fix checks m_image before attempting to eject and gives a different eject message if the image is cleared.