### PR TITLE
Fix hardware eject button under Win9x

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -361,6 +361,7 @@ void platform_init_eject_button(uint8_t eject_button)
 {
     if (eject_button & 1)
     {
+        //        pin                   function       pup   pdown  out    state fast
         gpio_conf(GPIO_EJECT_BTN_1_PIN, GPIO_FUNC_SIO, true, false, false, true, false);
         g_eject_buttons |= 1;
     }

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -517,7 +517,7 @@ static void zuluide_setup_sd_card()
             {
                 platform_disable_led();
             }
-            uint8_t eject_button = ini_getl("IDE", "eject_button", 0, CONFIGFILE);
+            uint8_t eject_button = ini_getl("IDE", "eject_button", 1, CONFIGFILE);
             platform_init_eject_button(eject_button);
         }
     }

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -802,7 +802,7 @@ bool IDEATAPIDevice::atapi_test_unit_ready(const uint8_t *cmd)
         {
             insert_next_media(m_image);
         }
-        // return atapi_cmd_not_ready_error();
+        return atapi_cmd_not_ready_error();
     }
     else if (!has_image())
     {
@@ -1346,6 +1346,8 @@ void IDEATAPIDevice::button_eject_media()
 {
     if (!m_removable.prevent_removable)
         eject_media();
+    else
+        dbgmsg("Attempted to eject media but host has set drive to prevent removable");
 }
 
 void IDEATAPIDevice::eject_media()

--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -775,8 +775,10 @@ bool IDECDROMDevice::atapi_get_event_status_notification(const uint8_t *cmd)
                 buf[5] = 0x02; // Media Present
                 buf[6] = 0; // Start slot
                 buf[7] = 0; // End slot
+                #if ENABLE_AUDIO_OUTPUT
+                  audio_stop();
+                #endif
                 esn_next_event();
-                eject_media();
             }
         }
         // output media no change
@@ -1582,14 +1584,18 @@ void IDECDROMDevice::eject_media()
     {
         logmsg("Device ejecting media, image already cleared");
     }
-    set_esn_event(esn_event_t::NoChange);
+    set_esn_event(esn_event_t::MMediaRemoval);
     m_removable.ejected = true;
 }
 
 void IDECDROMDevice::button_eject_media()
 {
     if (!m_removable.prevent_removable)
-        set_esn_event(esn_event_t::MMediaRemoval);
+    {
+        eject_media();
+    }
+    else
+        dbgmsg("Attempted to eject media but host has set drive to prevent removable");
 }
 
 void IDECDROMDevice::insert_media(IDEImage *image)

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -5,7 +5,7 @@
 
 # enable_usb_mass_storage = 0 # Disabled by default, set to 1 to enable access via USB mass storage
 
-# eject_button = 0 # bit field bit 0 = GPIO_11,  bit 1 = GPIO_14
+# eject_button = 1 # bit field bit 0 = GPIO_11 (default),  bit 1 = GPIO_14
 # ignore_prevent_removal = 0 # Set to 1 to ignore the host's ability to block ejection
 # has_drive1 = 0         # Force secondary drive detection result
 


### PR DESCRIPTION
Previously, the hardware eject button didn't support UNIT TEST polling, and only GET EVENT status notification polling, as used with Windoes XP and later, for checking of new media.

Also switch to enabling hardware eject button by default, so it is no longer necessary to explicitly enable it via the ini file.