### PR TITLE
Fix initialization without controller board

### DIFF
--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -67,7 +67,9 @@ namespace zuluide::i2c {
        Default constructor.
      */
     I2CServer();
-    void Init(TwoWire* wire, DeviceControlSafe* deviceControl);
+    void SetI2c(TwoWire* wire);
+
+    void SetDeviceControl(DeviceControlSafe* deviceControl);
     /**
        Handle updates to the system status. In practice, if an I2C client is
        subscribed to updates, a JSON representation of the system state is built
@@ -93,14 +95,14 @@ namespace zuluide::i2c {
      */
     bool CheckForDevice();
     /**
-       True iff the SSID and and password have been set.
+       True if the SSID and and password have been set.
      */
     bool WifiCredentialsSet();
   private:
     TwoWire* wire;
     DeviceControlSafe* deviceControl;
     bool isSubscribed;
-    bool initialized;
+    bool devControlSet;
     bool sendFiles;
     bool sendNextImage;
     bool isIterating;

--- a/lib/ZuluControl/src/i2c/i2c_server.cpp
+++ b/lib/ZuluControl/src/i2c/i2c_server.cpp
@@ -30,15 +30,18 @@
 
 using namespace zuluide::i2c;
 
-I2CServer::I2CServer() : deviceControl(nullptr), isSubscribed(false), initialized(false), sendFiles(false), sendNextImage(false), isIterating(false), isPresent(false) {
+I2CServer::I2CServer() : deviceControl(nullptr), isSubscribed(false), devControlSet(false), sendFiles(false), sendNextImage(false), isIterating(false), isPresent(false) {
 }
 
-void I2CServer::Init(TwoWire* wireValue, DeviceControlSafe* devControl) {
+void I2CServer::SetI2c(TwoWire* wireValue) {
   wire = wireValue;
-  deviceControl = devControl;
-  initialized = true;
 }
 
+void I2CServer::SetDeviceControl(DeviceControlSafe* devControl) 
+{
+    deviceControl = devControl;
+    devControlSet = true;
+}
 bool writeLengthPrefacedString(TwoWire *wire, uint8_t reg, uint16_t length, const char* buffer) {
   wire->beginTransmission(CLIENT_ADDR);
   wire->write(reg);
@@ -86,7 +89,7 @@ static uint16_t ReadInLength(TwoWire *wire) {
 }
 
 void I2CServer::Poll() {
-  if (!initialized || !isPresent) {
+  if (!devControlSet || !isPresent) {
     return;
   }
 
@@ -229,7 +232,7 @@ void I2CServer::Poll() {
       logmsg("Length was not 0 for fetch ssid request.");
     }
 
-    if (!WifiCredentialsSet()) {
+    if (ssid.length() == 0) {
       logmsg("Client requested the WiFi SSID, but the SSID is not configured.");
     }
         
@@ -243,7 +246,7 @@ void I2CServer::Poll() {
       logmsg("Length was not 0 for fetch ssid pass request.");
     }
 
-    if (!WifiCredentialsSet()) {
+    if (password.length() == 0) {
       logmsg("Client requested SSID password, but the SSID password is not configured.");
     }
     

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
@@ -105,7 +105,7 @@ void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 /**
    Attempts to determine whether the hardware UI or the web service is attached to the device.
  */
-bool platform_check_for_controller();
+uint8_t platform_check_for_controller();
 
 /**
    Sets the status controller connection used to process status events on the UI core.

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -352,10 +352,10 @@ void setupStatusController()
   }
 
   g_StatusController.AddObserver(status_observer);
-  platform_set_device_control(&g_StatusController);
 
   if (platform_check_for_controller())
   {
+    platform_set_device_control(&g_StatusController);
     platform_set_status_controller(&uiSafeStatusUpdater);
     platform_set_display_controller(g_DisplayController);
 


### PR DESCRIPTION
When there was no I2C controller board hooked up to the ZuluIDE, the I2C Pico W webserver was testing it's I2C connection before it set its I2C interface so it was acting on a nullptr.

Fixed messaging when either the SSID or password is not set. Before if either one was not set it would report both not being set.