### PR TITLE
Fix USB mass storage

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -38,6 +38,7 @@
 #include <pico/multicore.h>
 #include "rp2040_fpga.h"
 #include <strings.h>
+#include <RP2040USB.h>
 #include <SerialUSB.h>
 #include <class/cdc/cdc_device.h>
 #include <Wire.h>
@@ -270,6 +271,7 @@ void platform_late_init()
     audio_init();
 #endif
     platform_check_for_controller();
+    __USBStart();
 }
 
 uint8_t platform_check_for_controller()

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -525,13 +525,10 @@ static void zuluide_setup_sd_card()
 
 void zuluide_init(void)
 {
-    platform_init();
-
-    g_log_debug = ini_getbool("IDE", "debug", g_log_debug, CONFIGFILE);
-
-    platform_late_init();
-    zuluide_setup_sd_card();
-    g_ide_imagefile = IDEImageFile((uint8_t*)g_ide_buffer, sizeof(g_ide_buffer));
+  platform_init();
+  platform_late_init();
+  zuluide_setup_sd_card();
+  g_log_debug = ini_getbool("IDE", "debug", g_log_debug, CONFIGFILE);
 
 #ifdef PLATFORM_MASS_STORAGE
   static bool check_mass_storage = true;
@@ -548,12 +545,12 @@ void zuluide_init(void)
   }
 #endif
 
+  g_ide_imagefile = IDEImageFile((uint8_t*)g_ide_buffer, sizeof(g_ide_buffer));
+
   // Setup the status controller.
   setupStatusController();
 
   blinkStatus(BLINK_STATUS_OK);
-
-
   logmsg("Initialization complete!");
 }
 


### PR DESCRIPTION
After moving the initialization code to initVariant the mass storage was being checked before the USB system was initialized. The fix was take the arduino-pico framework USB initialization function and execute before the mass storage device is checked.

Also moved the debug flag to after the the SD card is initialized.