### PR TITLE
Migrate to latest pico sdk

### DIFF
--- a/boards/zuluide_rp2040.json
+++ b/boards/zuluide_rp2040.json
@@ -9,7 +9,7 @@
     },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
-    "extra_flags": "-D ARDUINO_RHC_ZULUIDE_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
+    "extra_flags": "-DARDUINO_GENERIC_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500 ",
     "f_cpu": "125000000L",
     "hwids": [
       [
@@ -22,7 +22,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "zuluide_rp2040"
+    "variant": "generic"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",
@@ -52,5 +52,5 @@
     ]
   },
   "url": "https://www.zuluide.com",
-  "vendor": "Rabbit Hole Computing"
+  "vendor": "Rabbit Hole Computing LLC"
 }

--- a/lib/ZuluControl/include/zuluide/images/image.h
+++ b/lib/ZuluControl/include/zuluide/images/image.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <string>
+#include <stdint.h>
 
 namespace zuluide::images {
 

--- a/lib/ZuluControl/include/zuluide/observer_transfer.h
+++ b/lib/ZuluControl/include/zuluide/observer_transfer.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <functional>
+#include <algorithm>
 #include <pico/util/queue.h>
 #include <zuluide/observable_ui_safe.h>
 #include <zuluide/observable_safe.h>

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -1081,19 +1081,6 @@ void zuluide_main_loop1(void)
     g_I2cServer.Poll();
 }
 
-
-extern "C"
-{
-    void setup1(void)
-    {
-        zuluide_setup1();
-    }
-    void loop1(void)
-    {
-        zuluide_main_loop1();
-    }
-}
-
 mutex_t* platform_get_log_mutex() {
   return &logMutex;
 }

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -167,6 +167,22 @@ static void reclock_to_default()
 
 }
 
+void platform_minimal_init()
+{
+    // SD card pins
+    // Card is used in SDIO mode, rp2040_sdio.cpp will redirect these to PIO1
+    //        pin             function       pup   pdown  out    state fast
+    gpio_conf(SDIO_CLK,       GPIO_FUNC_SIO, true, false, true,  true, true);
+    gpio_conf(SDIO_CMD,       GPIO_FUNC_SIO, true, false, false, true, true);
+    gpio_conf(SDIO_D0,        GPIO_FUNC_SIO, true, false, false, true, true);
+    gpio_conf(SDIO_D1,        GPIO_FUNC_SIO, true, false, false, true, true);
+    gpio_conf(SDIO_D2,        GPIO_FUNC_SIO, true, false, false, true, true);
+    gpio_conf(SDIO_D3,        GPIO_FUNC_SIO, true, false, false, true, true);
+
+    // Status LED
+    gpio_conf(STATUS_LED,     GPIO_FUNC_SIO, false,false, true,  false, false);
+}
+
 void platform_init()
 {
     // Make sure second core is stopped

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
@@ -61,6 +61,9 @@ void platform_emergency_log_save();
 // Initialize SD card and GPIO configuration
 void platform_init();
 
+// Just enough for the bootloader
+void platform_minimal_init();
+
 // Initialization for main application, not used for bootloader
 void platform_late_init();
 

--- a/lib/ZuluIDE_platform_RP2040/rp2040_sdio.cpp
+++ b/lib/ZuluIDE_platform_RP2040/rp2040_sdio.cpp
@@ -708,7 +708,9 @@ static void rp2040_sdio_tx_irq()
 // Check if transmission is complete
 sdio_status_t rp2040_sdio_tx_poll(uint32_t *bytes_complete)
 {
-    if (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk)
+    // 0x1FFUL = SCB_ICSR_VECTACTIVE_Msk
+    if (scb_hw->icsr & 0x1FFUL)
+
     {
         // Verify that IRQ handler gets called even if we are in hardfault handler
         rp2040_sdio_tx_irq();
@@ -784,6 +786,8 @@ void rp2040_sdio_init(int clock_divider)
     static bool resources_claimed = false;
     if (!resources_claimed)
     {
+        pio_sm_unclaim(SDIO_PIO, SDIO_CMD_SM);
+        pio_sm_unclaim(SDIO_PIO, SDIO_DATA_SM);
         pio_sm_claim(SDIO_PIO, SDIO_CMD_SM);
         pio_sm_claim(SDIO_PIO, SDIO_DATA_SM);
         dma_channel_claim(SDIO_DMA_CH);

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,10 +2,10 @@
 default_envs = ZuluIDE_RP2040
 
 [env:ZuluIDE_RP2040]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#5e87ae34ca025274df25b3303e9e9cb6c120123c
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#19e30129fb1428b823be585c787dcb4ac0d9014c
 board_build.core = earlephilhower
 platform_packages =
-    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v3.7.2-ZuluIDE
+    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.3.0-DaynaPORT
 framework = arduino
 board = zuluide_rp2040
 extra_scripts = src/build_bootloader.py
@@ -16,10 +16,10 @@ lib_deps =
     minIni
     ZuluControl
     ZuluI2S
+    ZuluIDE_platform_RP2040
     CUEParser=https://github.com/rabbitholecomputing/CUEParser
     adafruit/Adafruit GFX Library
     adafruit/Adafruit BusIO
-    ZuluIDE_platform_RP2040
     adafruit/Adafruit SSD1306
 debug_tool = cmsis-dap
 debug_build_flags =

--- a/src/ZuluIDE_bootloader.cpp
+++ b/src/ZuluIDE_bootloader.cpp
@@ -86,8 +86,6 @@ bool program_firmware(FsFile &file)
 
     for (int i = 0; i < num_pages; i++)
     {
-        platform_reset_watchdog();
-
         if (i % 2)
             LED_ON();
         else
@@ -130,9 +128,8 @@ static bool mountSDCard()
 extern "C"
 int bootloader_main(void)
 {
-    platform_init();
+    platform_minimal_init();
     g_log_debug = true;
-    platform_reset_watchdog();
 
     logmsg("Bootloader version: " __DATE__ " " __TIME__ " " PLATFORM_NAME);
 
@@ -144,7 +141,7 @@ int bootloader_main(void)
         {
             if (program_firmware(fwfile))
             {
-                logmsg("Firmware update successful!");
+                // logmsg("Firmware update successful!");
                 fwfile.close();
                 if (!SD.remove(name))
                 {
@@ -159,12 +156,8 @@ int bootloader_main(void)
             
         }
     }
-    else
-    {
-        logmsg("Bootloader SD card init failed");
-    }
 
-    logmsg("Bootloader continuing to main firmware");
+    // logmsg("Bootloader continuing to main firmware");
     platform_boot_to_main_firmware();
 
     return 0;

--- a/src/ZuluIDE_main.cpp
+++ b/src/ZuluIDE_main.cpp
@@ -29,7 +29,8 @@ int main(void)
 void zuluide_init(void);
 void zuluide_setup(void);
 void zuluide_main_loop(void);
-
+void zuluide_setup1(void);
+void zuluide_main_loop1(void);
 
 #ifdef USE_ARDUINO
 extern "C" 
@@ -46,6 +47,16 @@ extern "C"
     void loop(void)
     {
         zuluide_main_loop();
+    }
+
+    void setup1(void)
+    {
+        zuluide_setup1();
+    }
+
+    void loop1(void)
+    {
+        zuluide_main_loop1();
     }
 }
 #else

--- a/src/build_bootloader.py
+++ b/src/build_bootloader.py
@@ -3,7 +3,6 @@
 # as the main() function.
 
 import os
-
 Import("env")
 
 # Build a version of ZuluIDE_main.cpp that calls bootloader instead
@@ -19,7 +18,10 @@ dep_objs = []
 for nodelist in env["PIOBUILDFILES"]:
     for node in nodelist:
         filename = str(node.rfile())
-        if 'ZuluIDE_main' not in filename and 'ZuluIDE.' not in filename:
+        if ('ZuluIDE_main'  not in filename and
+            'ZuluIDE.'      not in filename and
+            'ide_'          not in filename and
+            'ZuluIDE_msc.'  not in filename):
             dep_objs.append(node)
 # print("Bootloader dependencies: ", type(dep_objs), str([str(f.rfile()) for f in dep_objs]))
 


### PR DESCRIPTION
Migrating caused the bootloader to be to large when attempting to build debug firmware

To free space the following was done
 - Only initializes the GPIOs that are required for the bootloader.
 - Got rid of the watchdog timer for the bootloader.
 - Commented out log messages that won't be logged via the
`platform_emergency_log_save()` function

This makes the bootloader.bin file 125KB just under the 128KB allocated. If the bootloader.bin files goes over 128KB again, it would make sense to have the bootloader to be it's own build.