### PR TITLE
Fix CD-AUDIO playback

### DIFF
--- a/lib/ZuluI2S/ZuluI2S.cpp
+++ b/lib/ZuluI2S/ZuluI2S.cpp
@@ -70,7 +70,6 @@ bool I2S::setBCLK(pin_size_t pin) {
     return true;
 }
 
-
 bool I2S::setMCLK(pin_size_t pin) {
     if (_running || (pin > 28)) {
         return false;
@@ -78,6 +77,7 @@ bool I2S::setMCLK(pin_size_t pin) {
     _pinMCLK = pin;
     return true;
 }
+
 bool I2S::setDATA(pin_size_t pin) {
     if (_running || (pin > 29)) {
         return false;
@@ -190,15 +190,24 @@ bool I2S::begin() {
     _hasPeeked = false;
     _isHolding = 0;
     int off = 0;
-    // _i2s = new PIOProgram(&pio_lsbj_out_program);
     _i2s = new PIOProgram(&pio_i2s_out_program);
+
+#ifdef I2S_PIO_HW
+    _pio = I2S_PIO_HW;
+    _sm = I2S_PIO_SM;
+    pio_sm_claim(_pio, _sm);
+    off = pio_add_program(I2S_PIO_HW, &pio_i2s_out_program);
+#else
+    // _i2s = new PIOProgram(&pio_lsbj_out_program);
+
     if (!_i2s->prepare(&_pio, &_sm, &off)) {
         _running = false;
         delete _i2s;
         _i2s = nullptr;
         return false;
     }
-    // pio_lsbj_out_program_init(_pio, _sm, off, _pinDOUT, _pinBCLK, _bps, _swapClocks);
+#endif
+    // pio lsbj_out_program_init(_pio, _sm, off, _pinDOUT, _pinBCLK, _bps, _swapClocks);
     pio_i2s_out_program_init(_pio, _sm, off, _pinDOUT, _pinBCLK, _bps, _swapClocks);
     setDivider(_div_int, _div_frac);
 

--- a/lib/ZuluI2S/ZuluI2S.cpp
+++ b/lib/ZuluI2S/ZuluI2S.cpp
@@ -24,38 +24,15 @@
 #include <pico/stdlib.h>
 
 
-I2S::I2S(PinMode direction) {
+I2S::I2S() {
     _running = false;
-    _div_int = 1;
+    _div_int = 48;
     _div_frac = 0;
     _bps = 16;
-    _writtenHalf = false;
-    _isOutput = direction == OUTPUT;
+    _pio = pio0_hw;
+    _sm = 1;
     _pinBCLK = 26;
     _pinDOUT = 28;
-    _pinMCLK = 25;
-    _MCLKenabled = false;
-#ifdef PIN_I2S_BCLK
-    _pinBCLK = PIN_I2S_BCLK;
-#endif
-
-#ifdef PIN_I2S_DOUT
-    if (_isOutput) {
-        _pinDOUT = PIN_I2S_DOUT;
-    }
-#endif
-
-#ifdef PIN_I2S_DIN
-    if (!_isOutput) {
-        _pinDOUT = PIN_I2S_DIN;
-    }
-#endif
-    _silenceSample = 0;
-    _isLSBJ = false;
-    _isTDM = false;
-    _tdmChannels = 8;
-    _swapClocks = false;
-    _multMCLK = 256;
 }
 
 I2S::~I2S() {
@@ -67,14 +44,6 @@ bool I2S::setBCLK(pin_size_t pin) {
         return false;
     }
     _pinBCLK = pin;
-    return true;
-}
-
-bool I2S::setMCLK(pin_size_t pin) {
-    if (_running || (pin > 28)) {
-        return false;
-    }
-    _pinMCLK = pin;
     return true;
 }
 
@@ -94,123 +63,32 @@ bool I2S::setBitsPerSample(int bps) {
     return true;
 }
 
-bool I2S::setDivider(uint16_t div_int, uint8_t div_frac) {
-    _div_int = div_int;
-    _div_frac = div_frac;
-    pio_sm_set_clkdiv_int_frac(_pio, _sm, _div_int, _div_frac);
-    return true;
-}
-
-uint I2S::getPioDreq() {
-    return pio_get_dreq(_pio, _sm, _isOutput);
-}
-
 volatile void *I2S::getPioFIFOAddr()
 {
     return (volatile void *)&_pio->txf[_sm];
 }
 
-bool I2S::setSysClk(int samplerate) { // optimise sys_clk for desired samplerate
-    if (samplerate % 11025 == 0) {
-        set_sys_clock_khz(I2SSYSCLK_44_1, false); // 147.6 unsuccessful - no I2S no USB
+bool I2S::setDivider(uint16_t div_int, uint8_t div_frac) {
+    _div_int = div_int;
+    _div_frac = div_frac;
+    return true;
+}
+
+uint I2S::getPioDreq() {
+    return pio_get_dreq(_pio, _sm, true);
+}
+
+bool I2S::begin(PIO pio, uint sm) {
+    if (_running)
         return true;
-    }
-    if (samplerate % 8000 == 0) {
-        set_sys_clock_khz(I2SSYSCLK_8, false);
-        return true;
-    }
-    return false;
-}
-
-bool I2S::setMCLKmult(int mult) {
-    if (_running) {
-        return false;
-    }
-    if ((mult % 64) == 0) {
-        _MCLKenabled = true;
-        _multMCLK = mult;
-        return true;
-    }
-    return false;
-}
-
-bool I2S::setLSBJFormat() {
-    if (_running || !_isOutput) {
-        return false;
-    }
-    _isLSBJ = true;
-    return true;
-}
-
-bool I2S::setTDMFormat() {
-    if (_running || !_isOutput) {
-        return false;
-    }
-    _isTDM = true;
-    return true;
-}
-
-bool I2S::setTDMChannels(int channels) {
-    if (_running || !_isOutput) {
-        return false;
-    }
-    _tdmChannels = channels;
-    return true;
-}
-
-bool I2S::swapClocks() {
-    if (_running || !_isOutput) {
-        return false;
-    }
-    _swapClocks = true;
-    return true;
-}
-
-// void I2S::onTransmit(void(*fn)(void)) {
-//     if (_isOutput) {
-//         _cb = fn;
-//         if (_running) {
-//             _arb->setCallback(_cb);
-//         }
-//     }
-// }
-
-// void I2S::onReceive(void(*fn)(void)) {
-//     if (!_isOutput) {
-//         _cb = fn;
-//         if (_running) {
-//             _arb->setCallback(_cb);
-//         }
-//     }
-// }
-
-
-bool I2S::begin() {
+    _pio = pio;
+    _sm = sm;
     _running = true;
-    _hasPeeked = false;
-    _isHolding = 0;
     int off = 0;
-    _i2s = new PIOProgram(&pio_i2s_out_program);
-
-#ifdef I2S_PIO_HW
-    _pio = I2S_PIO_HW;
-    _sm = I2S_PIO_SM;
     pio_sm_claim(_pio, _sm);
-    off = pio_add_program(I2S_PIO_HW, &pio_i2s_out_program);
-#else
-    // _i2s = new PIOProgram(&pio_lsbj_out_program);
-
-    if (!_i2s->prepare(&_pio, &_sm, &off)) {
-        _running = false;
-        delete _i2s;
-        _i2s = nullptr;
-        return false;
-    }
-#endif
-    // pio lsbj_out_program_init(_pio, _sm, off, _pinDOUT, _pinBCLK, _bps, _swapClocks);
-    pio_i2s_out_program_init(_pio, _sm, off, _pinDOUT, _pinBCLK, _bps, _swapClocks);
-    setDivider(_div_int, _div_frac);
-
+    off = pio_add_program(_pio, &pio_i2s_out_program);
+    pio_i2s_out_program_init(_pio, _sm, off, _pinDOUT, _pinBCLK, _bps);
+    pio_sm_set_clkdiv_int_frac(_pio, _sm, _div_int, _div_frac);
     pio_sm_set_enabled(_pio, _sm, true);
     return true;
 }
@@ -219,9 +97,5 @@ void I2S::end() {
     if (_running) {
         pio_sm_set_enabled(_pio, _sm, false);
         _running = false;
-        // delete _arb;
-        // _arb = nullptr;
-        delete _i2s;
-        _i2s = nullptr;
     }
 }

--- a/lib/ZuluI2S/ZuluI2S.h
+++ b/lib/ZuluI2S/ZuluI2S.h
@@ -20,126 +20,32 @@
 */
 
 #pragma once
-#include <Arduino.h>
-// #include "AudioBufferManager.h"
-// override dynamic setting of pio
-#define I2S_PIO_HW pio0
-#define I2S_PIO_SM 1
+
 class I2S {
 public:
-    I2S(PinMode direction = OUTPUT);
+    I2S();
     virtual ~I2S();
 
     bool setBCLK(pin_size_t pin);
     bool setDATA(pin_size_t pin);
-    bool setMCLK(pin_size_t pin);
     bool setBitsPerSample(int bps);
-    bool setLSBJFormat();
-    bool setTDMFormat();
-    bool setTDMChannels(int channels);
-    bool swapClocks();
-    bool setMCLKmult(int mult);
-    bool setSysClk(int samplerate);
+
     bool setDivider(uint16_t div_int, uint8_t div_frac);
     uint getPioDreq();
     volatile void *getPioFIFOAddr();
 
-    bool begin();
+    bool begin(PIO pio, uint sm);
     void end();
-
-    // from Stream
-    // virtual int available() override;
-    // virtual int read() override;
-    // virtual int peek() override;
-    // virtual void flush() override;
-
-    // from Print (see notes on write() methods below)
-    // virtual size_t write(const uint8_t *buffer, size_t size) override;
-    // virtual int availableForWrite() override;
-
-    // From the AR
-    // bool getOverUnderflow() {
-    //     if (!_running) {
-    //         return false;
-    //     } else {
-    //         return _arb->getOverUnderflow();
-    //     }
-    // }
-
-    // Try and make I2S::write() do what makes sense, namely write
-    // one sample (L or R) at the I2S configured bit width
-    // virtual size_t write(uint8_t s) override {
-    //     return _writeNatural(s & 0xff);
-    // }
-    // size_t write(int8_t s) {
-    //     return write((uint8_t)s);
-    // }
-    // size_t write(uint16_t s) {
-    //     return _writeNatural(s & 0xffff);
-    // }
-    // size_t write(int16_t s) {
-    //     return write((uint16_t)s);
-    // }
-    // size_t write(uint32_t s) {
-    //     return _writeNatural(s);
-    // }
-    // size_t write(int32_t s) {
-    //     return write((uint32_t)s);
-    // }
-
-    // Write 32 bit value to port, user responsible for packing/alignment, etc.
-    // size_t write(int32_t val, bool sync);
-
-    // Write sample to I2S port, will block until completed
-    // size_t write8(int8_t l, int8_t r);
-    // size_t write16(int16_t l, int16_t r);
-    // size_t write24(int32_t l, int32_t r); // Note that 24b must have values left-aligned (i.e. 0xABCDEF00)
-    // size_t write32(int32_t l, int32_t r);
-
-    // Read 32 bit value to port, user responsible for packing/alignment, etc.
-    // size_t read(int32_t *val, bool sync);
-
-    // Read samples from I2S port, will block until data available
-    // bool read8(int8_t *l, int8_t *r);
-    // bool read16(int16_t *l, int16_t *r);
-    // bool read24(int32_t *l, int32_t *r); // Note that 24b reads will be left-aligned (see above)
-    // bool read32(int32_t *l, int32_t *r);
-
-    // Note that these callback are called from **INTERRUPT CONTEXT** and hence
-    // should be in RAM, not FLASH, and should be quick to execute.
-    // void onTransmit(void(*)(void));
-    // void onReceive(void(*)(void));
 
 private:
     pin_size_t _pinBCLK;
     pin_size_t _pinDOUT;
-    pin_size_t _pinMCLK;
-    int _bps;
     uint16_t _div_int;
     uint8_t _div_frac;
-    int _multMCLK;
-    int32_t _silenceSample;
-    bool _isLSBJ;
-    bool _isTDM;
-    int _tdmChannels;
-    bool _isOutput;
-    bool _swapClocks;
-    bool _MCLKenabled;
-
+    int _bps;
     bool _running;
-
-    bool _hasPeeked;
-    int32_t _peekSaved;
-    uint32_t _writtenData;
-    bool _writtenHalf;
-
-    int32_t _holdWord = 0;
-    int _isHolding = 0;
 
     PIOProgram *_i2s;
     PIO _pio;
     int _sm;
-
-    static const int I2SSYSCLK_44_1 = 135600; // 44.1, 88.2 kHz sample rates
-    static const int I2SSYSCLK_8 = 147600;  // 8k, 16, 32, 48, 96, 192 kHz
 };

--- a/lib/ZuluI2S/ZuluI2S.h
+++ b/lib/ZuluI2S/ZuluI2S.h
@@ -22,7 +22,9 @@
 #pragma once
 #include <Arduino.h>
 // #include "AudioBufferManager.h"
-
+// override dynamic setting of pio
+#define I2S_PIO_HW pio0
+#define I2S_PIO_SM 1
 class I2S {
 public:
     I2S(PinMode direction = OUTPUT);

--- a/lib/ZuluI2S/zulu_pio_i2s.pio
+++ b/lib/ZuluI2S/zulu_pio_i2s.pio
@@ -19,16 +19,6 @@
 ; License along with this library; if not, write to the Free Software
 ; Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-.program pio_i2s_mclk
-; PIO SM clock is MCLK x 2
-; MCLK/BCLK sync is maintained by ensuring IN/OUT PIO SM clock dividers 
-; are x128, 384, 256, 512 or 768 multiples of MCLK SM divider as required.
-
-loop_mclk:
-	set pins, 1 ; toggle mclk
-	set pins, 0 
-	; Loop back to beginning...
-	
 .program pio_i2s_out
 .side_set 2   ; 0 = bclk, 1=wclk
 
@@ -50,168 +40,14 @@ right:
     out pins, 1      side 0b00 ; Last bit of right also has WCLK change
     ; Loop back to beginning...
 
-.program pio_i2s_out_swap
-.side_set 2   ; 0 = wclk, 1=bclk
-
-; The C code should place (number of bits/sample - 2) in Y and
-; also update the SHIFTCTRL to be 24 or 32 as appropriate
-
-;                           +----- BCLK
-;                           |+---- WCLK
-    mov x, y         side 0b10
-left:
-    out pins, 1      side 0b00
-    jmp x--, left    side 0b10
-    out pins, 1      side 0b01 ; Last bit of left has WCLK change per I2S spec
-
-    mov x, y         side 0b11
-right:
-    out pins, 1      side 0b01
-    jmp x--, right   side 0b11
-    out pins, 1      side 0b00 ; Last bit of right also has WCLK change
-    ; Loop back to beginning...
-
-
-.program pio_tdm_out
-.side_set 2   ; 0 = bclk, 1 = wclk
-; The C code should place (number of bits - 1) in Y and update SHIFTCTRL
-; to be 32 (as per the TDM specs)
-;                           +----- WCLK
-;                           |+---- BCLK
-    mov x, y         side 0b11
-bitloop:
-    out pins, 1      side 0b00
-    jmp x-- bitloop  side 0b01
-
-lastbit:
-    out pins, 1      side 0b10
-    ; Loop back to the beginning
-
-
-.program pio_tdm_out_swap
-.side_set 2   ; 0 = wclk, 1 = bclk
-; The C code should place (number of bits - 1) in Y and update SHIFTCTRL
-; to be 32 (as per the TDM specs)
-;                           +----- BCLK
-;                           |+---- WCLK
-    mov x, y         side 0b11
-bitloop:
-    out pins, 1      side 0b00
-    jmp x-- bitloop  side 0b10
-
-lastbit:
-    out pins, 1      side 0b01
-    ; Loop back to the beginning
-
-
-
-.program pio_lsbj_out
-.side_set 2   ; 0 = bclk, 1=wclk
-
-; The C code should place (number of bits/sample - 2) in Y and
-; also update the SHIFTCTRL to be 24 or 32 as appropriate
-
-;                           +----- WCLK
-;                           |+---- BCLK
-    mov x, y         side 0b01
-left:
-    out pins, 1      side 0b10
-    jmp x--, left    side 0b11
-    out pins, 1      side 0b10
-
-    mov x, y         side 0b11
-right:
-    out pins, 1      side 0b00
-    jmp x--, right   side 0b01
-    out pins, 1      side 0b00
-    ; Loop back to beginning...
-
-
-.program pio_lsbj_out_swap
-.side_set 2   ; 0 = wclk, 1=bclk
-
-; The C code should place (number of bits/sample - 2) in Y and
-; also update the SHIFTCTRL to be 24 or 32 as appropriate
-
-;                           +----- BCLK
-;                           |+---- WCLK
-    mov x, y         side 0b10
-left:
-    out pins, 1      side 0b01
-    jmp x--, left    side 0b11
-    out pins, 1      side 0b01
-
-    mov x, y         side 0b11
-right:
-    out pins, 1      side 0b00
-    jmp x--, right   side 0b10
-    out pins, 1      side 0b00
-    ; Loop back to beginning...
-
-
-    
-.program pio_i2s_in ; Note this is the same as _out, just "in" and not "out"
-.side_set 2   ; 0 = bclk, 1=wclk
-
-; The C code should place (number of bits/sample - 2) in Y and
-; also update the SHIFTCTRL to be 24 or 32 as appropriate
-
-;                           +----- WCLK
-;                           |+---- BCLK
-    mov x, y         side 0b00
-left:
-    in pins, 1       side 0b01
-    jmp x--, left    side 0b00
-    in pins, 1       side 0b11 ; Last bit of left has WCLK change per I2S spec
-
-    mov x, y         side 0b10
-right:
-    in pins, 1       side 0b11
-    jmp x--, right   side 0b10
-    in pins, 1       side 0b01 ; Last bit of right also has WCLK change
-    ; Loop back to beginning...
-
-
-.program pio_i2s_in_swap ; Note this is the same as _out, just "in" and not "out"
-.side_set 2   ; 0 = wclk, 1=bclk
-
-; The C code should place (number of bits/sample - 2) in Y and
-; also update the SHIFTCTRL to be 24 or 32 as appropriate
-
-;                           +----- BCLK
-;                           |+---- WCLK
-    mov x, y         side 0b00
-left:
-    in pins, 1       side 0b10
-    jmp x--, left    side 0b00
-    in pins, 1       side 0b11 ; Last bit of left has WCLK change per I2S spec
-
-    mov x, y         side 0b01
-right:
-    in pins, 1       side 0b11
-    jmp x--, right   side 0b01
-    in pins, 1       side 0b10 ; Last bit of right also has WCLK change
-    ; Loop back to beginning...
-
-
-
-
 % c-sdk {
 
-static inline void pio_i2s_MCLK_program_init(PIO pio, uint sm, uint offset, uint MCLK_pin) {
-    pio_gpio_init(pio, MCLK_pin);
-    pio_sm_set_consecutive_pindirs(pio, sm, MCLK_pin, 1, true);
-    pio_sm_config sm_config = pio_i2s_mclk_program_get_default_config(offset);   
-    sm_config_set_set_pins(&sm_config, MCLK_pin, 1);
-    pio_sm_init(pio, sm, offset, &sm_config);
-}
-
-static inline void pio_i2s_out_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits, bool swap) {
+static inline void pio_i2s_out_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits) {
     pio_gpio_init(pio, data_pin);
     pio_gpio_init(pio, clock_pin_base);
     pio_gpio_init(pio, clock_pin_base + 1);
 
-    pio_sm_config sm_config = swap ? pio_i2s_out_swap_program_get_default_config(offset) : pio_i2s_out_program_get_default_config(offset);
+    pio_sm_config sm_config =  pio_i2s_out_program_get_default_config(offset);
 
     sm_config_set_out_pins(&sm_config, data_pin, 1);
     sm_config_set_sideset_pins(&sm_config, clock_pin_base);
@@ -221,75 +57,6 @@ static inline void pio_i2s_out_program_init(PIO pio, uint sm, uint offset, uint 
     pio_sm_init(pio, sm, offset, &sm_config);
 
     uint pin_mask = (1u << data_pin) | (3u << clock_pin_base);
-    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
-    pio_sm_set_pins(pio, sm, 0); // clear pins
-
-    pio_sm_exec(pio, sm, pio_encode_set(pio_y, bits - 2));
-}
-
-static inline void pio_tdm_out_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits, bool swap, uint channels) {
-    pio_gpio_init(pio, data_pin);
-    pio_gpio_init(pio, clock_pin_base);
-    pio_gpio_init(pio, clock_pin_base + 1);
-
-    pio_sm_config sm_config = swap ? pio_tdm_out_swap_program_get_default_config(offset) : pio_tdm_out_program_get_default_config(offset);
-
-    sm_config_set_out_pins(&sm_config, data_pin, 1);
-    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
-    sm_config_set_out_shift(&sm_config, false, true, 32);
-    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
-
-    pio_sm_init(pio, sm, offset, &sm_config);
-
-    uint pin_mask = (1u << data_pin) | (3u << clock_pin_base);
-    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
-    pio_sm_set_pins(pio, sm, 0); // clear pins
-
-    // Can't set constant > 31, so push and pop/mov
-    pio_sm_put_blocking(pio, sm, bits * channels - 2);
-    pio_sm_exec(pio, sm, pio_encode_pull(false, false));
-    pio_sm_exec(pio, sm, pio_encode_mov(pio_y, pio_osr));
-    // Need to make OSR believe there's nothing left to shift out, or the 1st word will be the count we just passed in, not a sample
-    pio_sm_exec(pio, sm, pio_encode_out(pio_osr, 32));
-}
-
-
-static inline void pio_lsbj_out_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits, bool swap) {
-    pio_gpio_init(pio, data_pin);
-    pio_gpio_init(pio, clock_pin_base);
-    pio_gpio_init(pio, clock_pin_base + 1);
-
-    pio_sm_config sm_config = swap ? pio_lsbj_out_swap_program_get_default_config(offset) : pio_lsbj_out_program_get_default_config(offset);
-
-    sm_config_set_out_pins(&sm_config, data_pin, 1);
-    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
-    sm_config_set_out_shift(&sm_config, false, true, (bits <= 16) ? 2 * bits : bits);
-    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
-
-    pio_sm_init(pio, sm, offset, &sm_config);
-
-    uint pin_mask = (1u << data_pin) | (3u << clock_pin_base);
-    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
-    pio_sm_set_pins(pio, sm, 0); // clear pins
-
-    pio_sm_exec(pio, sm, pio_encode_set(pio_y, bits - 2));
-}
-
-static inline void pio_i2s_in_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits, bool swap) {
-    pio_gpio_init(pio, data_pin);
-    pio_gpio_init(pio, clock_pin_base);
-    pio_gpio_init(pio, clock_pin_base + 1);
-
-    pio_sm_config sm_config = swap ? pio_i2s_in_swap_program_get_default_config(offset) : pio_i2s_in_program_get_default_config(offset);
-
-    sm_config_set_in_pins(&sm_config, data_pin);
-    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
-    sm_config_set_in_shift(&sm_config, false, true, (bits <= 16) ? 2 * bits : bits);
-    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_RX);
-
-    pio_sm_init(pio, sm, offset, &sm_config);
-
-    uint pin_mask = 3u << clock_pin_base;
     pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
     pio_sm_set_pins(pio, sm, 0); // clear pins
 

--- a/lib/ZuluI2S/zulu_pio_i2s.pio.h
+++ b/lib/ZuluI2S/zulu_pio_i2s.pio.h
@@ -8,34 +8,6 @@
 #include "hardware/pio.h"
 #endif
 
-// ------------ //
-// pio_i2s_mclk //
-// ------------ //
-
-#define pio_i2s_mclk_wrap_target 0
-#define pio_i2s_mclk_wrap 1
-
-static const uint16_t pio_i2s_mclk_program_instructions[] = {
-    //     .wrap_target
-    0xe001, //  0: set    pins, 1
-    0xe000, //  1: set    pins, 0
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_i2s_mclk_program = {
-    .instructions = pio_i2s_mclk_program_instructions,
-    .length = 2,
-    .origin = -1,
-};
-
-static inline pio_sm_config pio_i2s_mclk_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_i2s_mclk_wrap_target, offset + pio_i2s_mclk_wrap);
-    return c;
-}
-#endif
-
 // ----------- //
 // pio_i2s_out //
 // ----------- //
@@ -44,16 +16,16 @@ static inline pio_sm_config pio_i2s_mclk_program_get_default_config(uint offset)
 #define pio_i2s_out_wrap 7
 
 static const uint16_t pio_i2s_out_program_instructions[] = {
-    //     .wrap_target
-    0xa822, //  0: mov    x, y            side 1
-    0x6001, //  1: out    pins, 1         side 0
-    0x0841, //  2: jmp    x--, 1          side 1
-    0x7001, //  3: out    pins, 1         side 2
-    0xb822, //  4: mov    x, y            side 3
-    0x7001, //  5: out    pins, 1         side 2
-    0x1845, //  6: jmp    x--, 5          side 3
-    0x6001, //  7: out    pins, 1         side 0
-    //     .wrap
+            //     .wrap_target
+    0xa822, //  0: mov    x, y            side 1     
+    0x6001, //  1: out    pins, 1         side 0     
+    0x0841, //  2: jmp    x--, 1          side 1     
+    0x7001, //  3: out    pins, 1         side 2     
+    0xb822, //  4: mov    x, y            side 3     
+    0x7001, //  5: out    pins, 1         side 2     
+    0x1845, //  6: jmp    x--, 5          side 3     
+    0x6001, //  7: out    pins, 1         side 0     
+            //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
@@ -69,256 +41,12 @@ static inline pio_sm_config pio_i2s_out_program_get_default_config(uint offset) 
     sm_config_set_sideset(&c, 2, false, false);
     return c;
 }
-#endif
 
-// ---------------- //
-// pio_i2s_out_swap //
-// ---------------- //
-
-#define pio_i2s_out_swap_wrap_target 0
-#define pio_i2s_out_swap_wrap 7
-
-static const uint16_t pio_i2s_out_swap_program_instructions[] = {
-    //     .wrap_target
-    0xb022, //  0: mov    x, y            side 2
-    0x6001, //  1: out    pins, 1         side 0
-    0x1041, //  2: jmp    x--, 1          side 2
-    0x6801, //  3: out    pins, 1         side 1
-    0xb822, //  4: mov    x, y            side 3
-    0x6801, //  5: out    pins, 1         side 1
-    0x1845, //  6: jmp    x--, 5          side 3
-    0x6001, //  7: out    pins, 1         side 0
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_i2s_out_swap_program = {
-    .instructions = pio_i2s_out_swap_program_instructions,
-    .length = 8,
-    .origin = -1,
-};
-
-static inline pio_sm_config pio_i2s_out_swap_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_i2s_out_swap_wrap_target, offset + pio_i2s_out_swap_wrap);
-    sm_config_set_sideset(&c, 2, false, false);
-    return c;
-}
-#endif
-
-// ----------- //
-// pio_tdm_out //
-// ----------- //
-
-#define pio_tdm_out_wrap_target 0
-#define pio_tdm_out_wrap 3
-
-static const uint16_t pio_tdm_out_program_instructions[] = {
-    //     .wrap_target
-    0xb822, //  0: mov    x, y            side 3
-    0x6001, //  1: out    pins, 1         side 0
-    0x0841, //  2: jmp    x--, 1          side 1
-    0x7001, //  3: out    pins, 1         side 2
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_tdm_out_program = {
-    .instructions = pio_tdm_out_program_instructions,
-    .length = 4,
-    .origin = -1,
-};
-
-static inline pio_sm_config pio_tdm_out_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_tdm_out_wrap_target, offset + pio_tdm_out_wrap);
-    sm_config_set_sideset(&c, 2, false, false);
-    return c;
-}
-#endif
-
-// ---------------- //
-// pio_tdm_out_swap //
-// ---------------- //
-
-#define pio_tdm_out_swap_wrap_target 0
-#define pio_tdm_out_swap_wrap 3
-
-static const uint16_t pio_tdm_out_swap_program_instructions[] = {
-    //     .wrap_target
-    0xb822, //  0: mov    x, y            side 3
-    0x6001, //  1: out    pins, 1         side 0
-    0x1041, //  2: jmp    x--, 1          side 2
-    0x6801, //  3: out    pins, 1         side 1
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_tdm_out_swap_program = {
-    .instructions = pio_tdm_out_swap_program_instructions,
-    .length = 4,
-    .origin = -1,
-};
-
-static inline pio_sm_config pio_tdm_out_swap_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_tdm_out_swap_wrap_target, offset + pio_tdm_out_swap_wrap);
-    sm_config_set_sideset(&c, 2, false, false);
-    return c;
-}
-#endif
-
-// ------------ //
-// pio_lsbj_out //
-// ------------ //
-
-#define pio_lsbj_out_wrap_target 0
-#define pio_lsbj_out_wrap 7
-
-static const uint16_t pio_lsbj_out_program_instructions[] = {
-    //     .wrap_target
-    0xa822, //  0: mov    x, y            side 1
-    0x7001, //  1: out    pins, 1         side 2
-    0x1841, //  2: jmp    x--, 1          side 3
-    0x7001, //  3: out    pins, 1         side 2
-    0xb822, //  4: mov    x, y            side 3
-    0x6001, //  5: out    pins, 1         side 0
-    0x0845, //  6: jmp    x--, 5          side 1
-    0x6001, //  7: out    pins, 1         side 0
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_lsbj_out_program = {
-    .instructions = pio_lsbj_out_program_instructions,
-    .length = 8,
-    .origin = -1,
-};
-
-static inline pio_sm_config pio_lsbj_out_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_lsbj_out_wrap_target, offset + pio_lsbj_out_wrap);
-    sm_config_set_sideset(&c, 2, false, false);
-    return c;
-}
-#endif
-
-// ----------------- //
-// pio_lsbj_out_swap //
-// ----------------- //
-
-#define pio_lsbj_out_swap_wrap_target 0
-#define pio_lsbj_out_swap_wrap 7
-
-static const uint16_t pio_lsbj_out_swap_program_instructions[] = {
-    //     .wrap_target
-    0xb022, //  0: mov    x, y            side 2
-    0x6801, //  1: out    pins, 1         side 1
-    0x1841, //  2: jmp    x--, 1          side 3
-    0x6801, //  3: out    pins, 1         side 1
-    0xb822, //  4: mov    x, y            side 3
-    0x6001, //  5: out    pins, 1         side 0
-    0x1045, //  6: jmp    x--, 5          side 2
-    0x6001, //  7: out    pins, 1         side 0
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_lsbj_out_swap_program = {
-    .instructions = pio_lsbj_out_swap_program_instructions,
-    .length = 8,
-    .origin = -1,
-};
-
-static inline pio_sm_config pio_lsbj_out_swap_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_lsbj_out_swap_wrap_target, offset + pio_lsbj_out_swap_wrap);
-    sm_config_set_sideset(&c, 2, false, false);
-    return c;
-}
-#endif
-
-// ---------- //
-// pio_i2s_in //
-// ---------- //
-
-#define pio_i2s_in_wrap_target 0
-#define pio_i2s_in_wrap 7
-
-static const uint16_t pio_i2s_in_program_instructions[] = {
-    //     .wrap_target
-    0xa022, //  0: mov    x, y            side 0
-    0x4801, //  1: in     pins, 1         side 1
-    0x0041, //  2: jmp    x--, 1          side 0
-    0x5801, //  3: in     pins, 1         side 3
-    0xb022, //  4: mov    x, y            side 2
-    0x5801, //  5: in     pins, 1         side 3
-    0x1045, //  6: jmp    x--, 5          side 2
-    0x4801, //  7: in     pins, 1         side 1
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_i2s_in_program = {
-    .instructions = pio_i2s_in_program_instructions,
-    .length = 8,
-    .origin = -1,
-};
-
-static inline pio_sm_config pio_i2s_in_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_i2s_in_wrap_target, offset + pio_i2s_in_wrap);
-    sm_config_set_sideset(&c, 2, false, false);
-    return c;
-}
-#endif
-
-// --------------- //
-// pio_i2s_in_swap //
-// --------------- //
-
-#define pio_i2s_in_swap_wrap_target 0
-#define pio_i2s_in_swap_wrap 7
-
-static const uint16_t pio_i2s_in_swap_program_instructions[] = {
-    //     .wrap_target
-    0xa022, //  0: mov    x, y            side 0
-    0x5001, //  1: in     pins, 1         side 2
-    0x0041, //  2: jmp    x--, 1          side 0
-    0x5801, //  3: in     pins, 1         side 3
-    0xa822, //  4: mov    x, y            side 1
-    0x5801, //  5: in     pins, 1         side 3
-    0x0845, //  6: jmp    x--, 5          side 1
-    0x5001, //  7: in     pins, 1         side 2
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_i2s_in_swap_program = {
-    .instructions = pio_i2s_in_swap_program_instructions,
-    .length = 8,
-    .origin = -1,
-};
-
-static inline pio_sm_config pio_i2s_in_swap_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_i2s_in_swap_wrap_target, offset + pio_i2s_in_swap_wrap);
-    sm_config_set_sideset(&c, 2, false, false);
-    return c;
-}
-
-static inline void pio_i2s_MCLK_program_init(PIO pio, uint sm, uint offset, uint MCLK_pin) {
-    pio_gpio_init(pio, MCLK_pin);
-    pio_sm_set_consecutive_pindirs(pio, sm, MCLK_pin, 1, true);
-    pio_sm_config sm_config = pio_i2s_mclk_program_get_default_config(offset);
-    sm_config_set_set_pins(&sm_config, MCLK_pin, 1);
-    pio_sm_init(pio, sm, offset, &sm_config);
-}
-static inline void pio_i2s_out_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits, bool swap) {
+static inline void pio_i2s_out_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits) {
     pio_gpio_init(pio, data_pin);
     pio_gpio_init(pio, clock_pin_base);
     pio_gpio_init(pio, clock_pin_base + 1);
-    pio_sm_config sm_config = pio_i2s_out_program_get_default_config(offset);
+    pio_sm_config sm_config =  pio_i2s_out_program_get_default_config(offset);
     sm_config_set_out_pins(&sm_config, data_pin, 1);
     sm_config_set_sideset_pins(&sm_config, clock_pin_base);
     sm_config_set_out_shift(&sm_config, false, true, (bits <= 16) ? 2 * bits : bits);
@@ -329,56 +57,5 @@ static inline void pio_i2s_out_program_init(PIO pio, uint sm, uint offset, uint 
     pio_sm_set_pins(pio, sm, 0); // clear pins
     pio_sm_exec(pio, sm, pio_encode_set(pio_y, bits - 2));
 }
-static inline void pio_tdm_out_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits, bool swap, uint channels) {
-    pio_gpio_init(pio, data_pin);
-    pio_gpio_init(pio, clock_pin_base);
-    pio_gpio_init(pio, clock_pin_base + 1);
-    pio_sm_config sm_config = swap ? pio_tdm_out_swap_program_get_default_config(offset) : pio_tdm_out_program_get_default_config(offset);
-    sm_config_set_out_pins(&sm_config, data_pin, 1);
-    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
-    sm_config_set_out_shift(&sm_config, false, true, 32);
-    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
-    pio_sm_init(pio, sm, offset, &sm_config);
-    uint pin_mask = (1u << data_pin) | (3u << clock_pin_base);
-    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
-    pio_sm_set_pins(pio, sm, 0); // clear pins
-    // Can't set constant > 31, so push and pop/mov
-    pio_sm_put_blocking(pio, sm, bits * channels - 2);
-    pio_sm_exec(pio, sm, pio_encode_pull(false, false));
-    pio_sm_exec(pio, sm, pio_encode_mov(pio_y, pio_osr));
-    // Need to make OSR believe there's nothing left to shift out, or the 1st word will be the count we just passed in, not a sample
-    pio_sm_exec(pio, sm, pio_encode_out(pio_osr, 32));
-}
-static inline void pio_lsbj_out_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits, bool swap) {
-    pio_gpio_init(pio, data_pin);
-    pio_gpio_init(pio, clock_pin_base);
-    pio_gpio_init(pio, clock_pin_base + 1);
-    pio_sm_config sm_config = swap ? pio_lsbj_out_swap_program_get_default_config(offset) : pio_lsbj_out_program_get_default_config(offset);
-    sm_config_set_out_pins(&sm_config, data_pin, 1);
-    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
-    sm_config_set_out_shift(&sm_config, false, true, (bits <= 16) ? 2 * bits : bits);
-    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
-    pio_sm_init(pio, sm, offset, &sm_config);
-    uint pin_mask = (1u << data_pin) | (3u << clock_pin_base);
-    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
-    pio_sm_set_pins(pio, sm, 0); // clear pins
-    pio_sm_exec(pio, sm, pio_encode_set(pio_y, bits - 2));
-}
-static inline void pio_i2s_in_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base, uint bits, bool swap) {
-    pio_gpio_init(pio, data_pin);
-    pio_gpio_init(pio, clock_pin_base);
-    pio_gpio_init(pio, clock_pin_base + 1);
-    pio_sm_config sm_config = swap ? pio_i2s_in_swap_program_get_default_config(offset) : pio_i2s_in_program_get_default_config(offset);
-    sm_config_set_in_pins(&sm_config, data_pin);
-    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
-    sm_config_set_in_shift(&sm_config, false, true, (bits <= 16) ? 2 * bits : bits);
-    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_RX);
-    pio_sm_init(pio, sm, offset, &sm_config);
-    uint pin_mask = 3u << clock_pin_base;
-    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
-    pio_sm_set_pins(pio, sm, 0); // clear pins
-    pio_sm_exec(pio, sm, pio_encode_set(pio_y, bits - 2));
-}
 
 #endif
-

--- a/lib/ZuluIDE_platform_RP2040/audio.cpp
+++ b/lib/ZuluIDE_platform_RP2040/audio.cpp
@@ -136,8 +136,8 @@ static void snd_process_b() {
  **********************************************************************************************/
 static bool setup_playback(uint32_t start, uint32_t length, bool continued)
 {
-    static  uint32_t last_length = 0;
-    static  uint32_t last_start = 0;
+    static uint32_t last_length = 0;
+    static uint32_t last_start = 0;
     static uint8_t last_track_number = 0;
 
     if (!continued)

--- a/lib/ZuluIDE_platform_RP2040/audio.cpp
+++ b/lib/ZuluIDE_platform_RP2040/audio.cpp
@@ -381,7 +381,7 @@ void audio_init() {
     // 44.1KHz to the nearest integer with a sys clk of 135.43MHz and 2 x 16-bit samples with the pio clock running 2x I2S clock
     // 135.43Mhz / 16 / 2 / 2 / 44.1KHz = 47.98 ~= 48
     i2s.setDivider(48, 0);
-    i2s.begin();
+    i2s.begin(I2S_PIO_HW, I2S_PIO_SM);
     dma_channel_claim(SOUND_DMA_CHA);
 	dma_channel_claim(SOUND_DMA_CHB);
 

--- a/lib/ZuluIDE_platform_RP2040/audio.h
+++ b/lib/ZuluIDE_platform_RP2040/audio.h
@@ -20,6 +20,11 @@
 
 #include <stdint.h>
 
+
+// i2s PIO settings
+#define I2S_PIO_HW pio0_hw
+#define I2S_PIO_SM 1
+
 // audio subsystem DMA channels
 #define SOUND_DMA_CHA 6
 #define SOUND_DMA_CHB 7

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -380,12 +380,12 @@ void setupStatusController()
     g_StatusController.EndUpdate();
   }
 
-  loadFirstImage();
-
   if (isPrimary)
     ide_protocol_init(g_ide_device, NULL); // Primary device
   else
     ide_protocol_init(NULL, g_ide_device); // Secondary device
+
+  loadFirstImage();
 }
 
 void loadFirstImage() {
@@ -429,6 +429,9 @@ void loadFirstImage() {
       blinkStatus(BLINK_ERROR_NO_IMAGES);
     }
   }
+
+  if (loadedFirstImage)
+     g_ide_device->post_image_setup();
 
   imgIterator.Cleanup();
 }

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,8 +27,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.01.16"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2025.01.20"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -41,7 +41,7 @@ class IDEATAPIDevice: public IDEDevice, public IDEImage::Callback
 {
 public:
     virtual void initialize(int devidx) override;
-
+    virtual void post_image_setup() override {;};
     virtual void reset() override;
 
     virtual void set_image(IDEImage *image);

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -35,6 +35,9 @@ public:
     // Loads configuration
     virtual void initialize(int devidx);
 
+    // Finishes initialization after the first image has been loaded
+    virtual void post_image_setup() = 0;
+
     // Resets member variables after IDE/ATA reset
     virtual void reset() = 0;
 

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -65,7 +65,10 @@ void IDERigidDevice::initialize(int devidx)
     memset(&m_ata_state, 0, sizeof(m_ata_state));
     memset(&m_removable, 0, sizeof(m_removable));
     m_devinfo.bytes_per_sector = 512;
+}
 
+void IDERigidDevice::post_image_setup()
+{
     uint64_t cap = capacity();
     uint64_t lba = capacity_lba();
 
@@ -122,7 +125,6 @@ void IDERigidDevice::reset()
     m_devinfo.current_sectors = m_devinfo.sectors_per_track;
     memset(&m_removable, 0, sizeof(m_removable));
 }
-
 
 void IDERigidDevice::set_image(IDEImage *image)
 {

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -36,6 +36,8 @@ class IDERigidDevice: public IDEDevice, public IDEImage::Callback
 public:
     virtual void initialize(int devidx) override;
 
+    virtual void post_image_setup() override;
+
     virtual void reset() override;
 
     virtual void set_image(IDEImage *image);


### PR DESCRIPTION
The updated arduino-pico PlatformIO SDK/framework's dynamically allocated PIO method that was used in the I2S initialization was conflicting with the manually setup SDIO PIO.

Forcing the I2S PIO to a manually set PIO and state machine fixes the issue reported in #170 