### PR TITLE
User friendly SD card errors

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/sd_card_sdio.cpp
+++ b/lib/ZuluIDE_platform_RP2040/sd_card_sdio.cpp
@@ -46,7 +46,13 @@ static uint32_t g_sdio_sector_count;
 static bool logSDError(int line)
 {
     g_sdio_error_line = line;
-    logmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
+    // suppressing Error code 2s (timeouts) the usually occur when the SD card is removed.
+    if (!dbgmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error) &&
+        g_sdio_error != 2)
+    {
+        logmsg("Unexpected SD card error on line ", line, ", error code ", (int)g_sdio_error);
+    }
+
     return false;
 }
 

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -498,8 +498,6 @@ static void zuluide_setup_sd_card()
     if(!g_sdcard_present)
     {
         g_StatusController.SetIsCardPresent(false);
-        logmsg("SD card init failed, sdErrorCode: ", (int)SD.sdErrorCode(),
-                    " sdErrorData: ", (int)SD.sdErrorData());
         blinkStatus(BLINK_ERROR_NO_SD_CARD);
     }
     else

--- a/src/ZuluIDE_log.h
+++ b/src/ZuluIDE_log.h
@@ -93,7 +93,7 @@ inline void logmsg(Params... params)
 
 // Format a complete debug message
 template<typename... Params>
-inline void dbgmsg(Params... params)
+inline bool dbgmsg(Params... params)
 {
     if (g_log_debug)
     {
@@ -101,4 +101,5 @@ inline void dbgmsg(Params... params)
         log_raw(params...);
         log_raw("\r\n");
     }
+    return g_log_debug;
 }


### PR DESCRIPTION
Suppress timeout errors that occur when the SD card is removed. Other SD errors are still logged to the user if they occur. In debug mode the timeout errors are included in the logging.

Changed the behavior of dbgmsg, it now returns the state of g_log_debug. This allows printing a different message if debug is disabled that may be more user friendly. Or in this case, the code filters what should be included in the normal logmsg while everything is included in the dbgmsg.