### PR TITLE
Fix Win9X CD playback and proper TOC reporting

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ lib_deps =
     ZuluControl
     ZuluI2S
     ZuluIDE_platform_RP2040
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#fix/cd-audio-offset
     adafruit/Adafruit GFX Library
     adafruit/Adafruit BusIO
     adafruit/Adafruit SSD1306

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ lib_deps =
     ZuluControl
     ZuluI2S
     ZuluIDE_platform_RP2040
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#fix/cd-audio-offset
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2025.02.25
     adafruit/Adafruit GFX Library
     adafruit/Adafruit BusIO
     adafruit/Adafruit SSD1306

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,7 +27,7 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.01.28"
+#define FW_VER_NUM      "2025.02.25"
 #define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 

--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -910,9 +910,8 @@ bool IDECDROMDevice::atapi_pause_resume_audio(const uint8_t *cmd)
 bool IDECDROMDevice::atapi_seek_10(const uint8_t *cmd)
 {
     uint32_t lba = parse_be32(&cmd[2]);
-    dbgmsg("---- Seek 10 - LBA: ", lba, " - seek not implemented - Win95 uses to pause audio ");
 #ifdef ENABLE_AUDIO_OUTPUT
-    doStopAudio();
+    doPlayAudio(lba, 0);
 #endif
     return atapi_cmd_ok();
 }


### PR DESCRIPTION
Proper track changes for Win9x cd player. There was a change needed
to the audio_get_lba_position() due to the file_offset in the CUEParser
being the start of index1 in the cue file and the start of the track
being index0 before index1. This was causing a negative number in
a calculation of unsigned numbers resulting into weird track changes
because the Read Sub-Channel command sending the wrong LBA position.

This should also pulls in a change to the CUEPraser library to give
proper TOC timings if a PREGAP is in the cue file.

These fixes address issue https://github.com/ZuluIDE/ZuluIDE-firmware/issues/179