### PR TITLE
Fix play audio 12 and 10 ATAPI commands

### DIFF
--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -832,7 +832,7 @@ bool IDECDROMDevice::atapi_start_stop_unit(const uint8_t *cmd)
 bool IDECDROMDevice::atapi_play_audio_10(const uint8_t *cmd)
 {
     uint32_t lba = parse_be32(&cmd[2]);
-    uint32_t blocks = parse_be32(&cmd[6]);
+    uint16_t blocks = parse_be16(&cmd[7]);
 
     return doPlayAudio(lba, blocks);
 }
@@ -840,7 +840,7 @@ bool IDECDROMDevice::atapi_play_audio_10(const uint8_t *cmd)
 bool IDECDROMDevice::atapi_play_audio_12(const uint8_t *cmd)
 {
     uint32_t lba = parse_be32(&cmd[2]);
-    uint16_t blocks = parse_be16(&cmd[7]);
+    uint32_t blocks = parse_be32(&cmd[6]);
 
     return doPlayAudio(lba, blocks);
 


### PR DESCRIPTION
The parsing of the play duration was swapped between "Play Audio 10" and "Play Audio 12". This is to fix issue https://github.com/ZuluIDE/ZuluIDE-firmware/issues/178