### PR TITLE
Add max volume for CD audio analog out

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -285,6 +285,7 @@ void platform_late_init()
 #ifdef ENABLE_AUDIO_OUTPUT
     // one-time control setup for DMA channels and second core
     audio_init();
+    audio_set_max_volume((uint8_t) ini_getl("IDE", "max_volume", 100, CONFIGFILE));
 #endif
     platform_check_for_controller();
     __USBStart();

--- a/lib/ZuluIDE_platform_RP2040/audio.cpp
+++ b/lib/ZuluIDE_platform_RP2040/audio.cpp
@@ -83,6 +83,7 @@ static CUETrackInfo current_track = {0};
 static audio_status_code audio_last_status = ASC_NO_STATUS;
 // volume information for targets
 static volatile uint8_t volume[2] = {DEFAULT_VOLUME_LEVEL, DEFAULT_VOLUME_LEVEL};
+static uint8_t max_volume = 100;
 static volatile uint16_t channel = AUDIO_CHANNEL_ENABLE_MASK;
 
 // mechanism for cleanly stopping DMA units
@@ -109,10 +110,10 @@ static void snd_encode(int16_t* samples, int16_t* output_buf, uint16_t len) {
             if (i % 2 == 0)
             {
                 temp = output_buf[i+1];
-                output_buf[i+1] = (int16_t)(((int32_t)samples[i]) * (vol[0]) / 255);
+                output_buf[i+1] = (int16_t)(((int64_t)samples[i]) * (vol[0]) * max_volume / 25500);
             }
             else
-                output_buf[i-1] = (int16_t)(((int32_t)temp) * (vol[1]) / 255);
+                output_buf[i-1] = (int16_t)(((int64_t)temp) * (vol[1]) * max_volume / 25500);
         }
     }
 }
@@ -631,6 +632,11 @@ uint16_t audio_get_volume() {
 void audio_set_volume(uint8_t lvol, uint8_t rvol) {
     volume[0] = lvol;
     volume[1] = rvol;
+}
+
+void audio_set_max_volume(uint8_t max_vol)
+{
+    max_volume = max_vol;
 }
 
 uint16_t audio_get_channel() {

--- a/lib/ZuluIDE_platform_RP2040/audio.h
+++ b/lib/ZuluIDE_platform_RP2040/audio.h
@@ -47,6 +47,12 @@ bool audio_is_active();
 void audio_init();
 
 /**
+ * Set Max volume percentage
+ * \param max_vol Max volume from 100 to 0 (mute)
+ */
+void audio_set_max_volume(uint8_t max_vol);
+
+/**
  * Called from platform_poll() to fill sample buffer(s) if needed.
  */
 void audio_poll();

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -41,6 +41,8 @@
 
 # access_delay = 0   # Add extra delay (milliseconds) before answering to commands
 
+#max_volume = 100 # Audio max volume 0 - 100 (default)
+
 [UI]
 # An additional Pico W is required to utilize this experimental functionality, which is not yet generally available.
 #wifipassword=MY_PASSWORD # Password for the WIFI network.


### PR DESCRIPTION
The DAC for the ZuluIDE can be really loud, this allows the volume to be scaled down by a percentage from 0 to 100 via `max_volume` in `zuluide.ini` file.