### PR TITLE
Fixes for CD ejection and add ATAPI_CMD_LOAD_UNLOAD_MEDIUM

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -685,6 +685,7 @@ bool IDEATAPIDevice::handle_atapi_command(const uint8_t *cmd)
     {
         case ATAPI_CMD_TEST_UNIT_READY: return atapi_test_unit_ready(cmd);
         case ATAPI_CMD_START_STOP_UNIT: return atapi_start_stop_unit(cmd);
+        case ATAPI_CMD_LOAD_UNLOAD_MEDIUM: return atapi_load_unload_medium(cmd);
         case ATAPI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL: return atapi_prevent_allow_removal(cmd);
         case ATAPI_CMD_MODE_SENSE6:     return atapi_mode_sense(cmd);
         case ATAPI_CMD_MODE_SENSE10:    return atapi_mode_sense(cmd);
@@ -845,6 +846,18 @@ bool IDEATAPIDevice::atapi_start_stop_unit(const uint8_t *cmd)
 
 }
 
+bool IDEATAPIDevice::atapi_load_unload_medium(const uint8_t *cmd)
+{
+    uint8_t slot = cmd[8];
+
+    if (slot != 0)
+    {
+        return atapi_cmd_error(ATAPI_SENSE_ILLEGAL_REQ, ATAPI_ASC_NO_MEDIUM);
+    }
+
+    // cmd[4] works the same as with start_stop_unit().
+    return atapi_start_stop_unit(cmd);
+}
 
 bool IDEATAPIDevice::atapi_prevent_allow_removal(const uint8_t *cmd)
 {

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -132,6 +132,7 @@ protected:
         bool prevent_removable;
         bool prevent_persistent;
         bool ignore_prevent_removal;
+        uint32_t eject_time;
     } m_removable;
 
     // Buffer used for responses, ide_phy code benefits from this being aligned to 32 bits
@@ -213,4 +214,7 @@ protected:
 
     // Set not ready if enabled via config ini
     virtual void set_not_ready(bool not_ready);
+
+    // Wait a moment after ejection before reinsertion
+    bool check_time_after_eject();
 };

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -183,6 +183,7 @@ protected:
     virtual bool handle_atapi_command(const uint8_t *cmd);
     virtual bool atapi_test_unit_ready(const uint8_t *cmd);
     virtual bool atapi_start_stop_unit(const uint8_t *cmd);
+    virtual bool atapi_load_unload_medium(const uint8_t *cmd);
     virtual bool atapi_prevent_allow_removal(const uint8_t *cmd);
     virtual bool atapi_inquiry(const uint8_t *cmd);
     virtual bool atapi_mode_sense(const uint8_t *cmd);


### PR DESCRIPTION
Running `eject /dev/cdrom` from Linux resulted in an infinite loop.

Fixed by:
* Report ejection event only once, even if host requests ejection again
* Wait 500 ms before automatic reinsertion

I think we possibly shouldn't be sending EjectRequest events at all if the ejection was requested by the IDE host.
But for now this fixes the issue while minimizing the chance of regressions on other platforms.

Also added the CD-changer specific `ATAPI_CMD_LOAD_UNLOAD_MEDIUM` which was reported as being sometimes called. Because we don't report multiple slots, this is equivalent to `ATAPI_CMD_START_STOP_UNIT`.