### PR TITLE
Decode url param image name and version the Controller I2C API

### DIFF
--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -27,6 +27,9 @@
 #include <zuluide/images/image_iterator.h>
 #include <string>
 
+#define I2C_API_VERSION "2.0.0"
+
+#define I2C_SERVER_API_VERSION  0x1
 #define I2C_SERVER_SYSTEM_STATUS_JSON  0xA
 #define I2C_SERVER_IMAGE_JSON  0xB
 #define I2C_SERVER_POLL_CLIENT 0xC
@@ -35,6 +38,8 @@
 #define I2C_SERVER_RESET 0xF
 
 #define I2C_CLIENT_NOOP 0x0
+
+#define I2C_CLIENT_API_VERSION 0x01
 #define I2C_CLIENT_SUBSCRIBE_STATUS_JSON  0xA
 #define I2C_CLIENT_LOAD_IMAGE  0xB
 #define I2C_CLIENT_EJECT_IMAGE  0xC
@@ -113,5 +118,7 @@ namespace zuluide::i2c {
     std::string status;
     std::string ssid;
     std::string password;
+    unsigned long remoteMajorVersion;
+    std::string remoteVersionString;
   };
 }

--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -98,6 +98,8 @@ namespace zuluide::i2c {
        True if the SSID and and password have been set.
      */
     bool WifiCredentialsSet();
+  protected:
+    std::string UnescapeUrl(const std::string& str);
   private:
     TwoWire* wire;
     DeviceControlSafe* deviceControl;

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,8 +27,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.03.25"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2025.03.31"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths


### PR DESCRIPTION
This is for issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/192
Filenames with "&" fail to load via the web interface with a PicoW
control board.

The issue is the filename string was being sent as a url without being
encoded. Since "&" is special character as a URL parameter the
string wasn't being received properly by the ZuluIDE.

Now encoding URL parameter in the https://github.com/ZuluIDE/ZuluIDE-HTTP-PicoW
repo and and escaping the url in this repo for the ZuluIDE firmware.


Also receive and send the I2C API version between the server (ZuluIDE)
and the client, device on the ZuluIDE's I2C bus like a Pico W with
ZuluIDE HTTP PicoW firmware. It will log a message if the major
versions of the the API's conflict.
