### PR TITLE
Remove UnescapeUrl

### DIFF
--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -103,8 +103,7 @@ namespace zuluide::i2c {
        True if the SSID and and password have been set.
      */
     bool WifiCredentialsSet();
-  protected:
-    std::string UnescapeUrl(const std::string& str);
+
   private:
     TwoWire* wire;
     DeviceControlSafe* deviceControl;

--- a/lib/ZuluControl/src/i2c/i2c_server.cpp
+++ b/lib/ZuluControl/src/i2c/i2c_server.cpp
@@ -238,12 +238,11 @@ void I2CServer::Poll() {
       }
       if (buffer[0] != '\0')
       {
-        std::string encoded_url = buffer;
-        std::string unencoded_url = UnescapeUrl(encoded_url);
-        logmsg("Client requested the current image be set to:", unencoded_url.c_str());
-        mutex_enter_blocking(platform_get_log_mutex());  
+
+        logmsg("Client requested the current image be set to:", buffer);
+        mutex_enter_blocking(platform_get_log_mutex());
         iterator.Reset();
-        bool found_file = iterator.MoveToFile(unencoded_url.c_str());
+        bool found_file = iterator.MoveToFile(buffer);
         zuluide::images::Image toLoad(std::string(), 0);
         toLoad = iterator.Get();
         iterator.Cleanup();
@@ -377,22 +376,4 @@ void I2CServer::SetPassword(std::string &value) {
 
 bool I2CServer::WifiCredentialsSet() {
   return !ssid.empty() && !password.empty();
-}
-
-std::string I2CServer::UnescapeUrl(const std::string& str) {
-    std::string result;
-    for (size_t i = 0; i < str.length(); ++i) {
-        if (str[i] == '%' && i + 2 < str.length()) {
-            if (std::isxdigit(str[i + 1]) && std::isxdigit(str[i + 2])) {
-                char hex[3] = {str[i + 1], str[i + 2], 0};
-                result += static_cast<char>(std::strtol(hex, nullptr, 16));
-                i += 2;
-            } else {
-                result += str[i];
-            }
-        } else {
-            result += str[i];
-        }
-    }
-    return result;
 }


### PR DESCRIPTION
The string is now properly decoded in the code for the shield before it is sent to ZuluIDE over I2C so decoding in the ZuluIDE is not required.