### PR TITLE
Fix image type inference

### DIFF
--- a/lib/ZuluControl/include/zuluide/images/image.h
+++ b/lib/ZuluControl/include/zuluide/images/image.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <stdint.h>
+#include <zuluide/ide_drive_type.h>>
 
 namespace zuluide::images {
 
@@ -34,13 +35,14 @@ namespace zuluide::images {
       zip100,
       zip250,
       zip750,
-      generic,  
-      unknown  
+      removable,
+      harddrive,
+      unknown
     };
-    
+
     Image(std::string filename, uint64_t sizeInBytes = 0);
     Image(std::string filename, ImageType imageType, uint64_t sizeInBytes = 0);
-    
+
     const std::string& GetFilename() const;
     ImageType GetImageType();
     bool operator==(const Image& other) const;
@@ -48,11 +50,15 @@ namespace zuluide::images {
 
     std::string ToJson();
     std::string ToJson(const char* fieldName);
-    
+    static drive_type_t ToDriveType(const ImageType toConvert);
+    static const char* GetImagePrefix(const ImageType toConvert);
+    static ImageType InferImageTypeFromImagePrefix(const char* prefix);
+    static ImageType InferImageTypeFromFileName(const char *filename);
+
   private:
     std::string filenm;
     ImageType imgType;
     uint64_t fileSizeBytes;
   };
-  
+
 }

--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -62,9 +62,11 @@ namespace zuluide::images {
 	Defaults to true.
      **/
     void SetParseMultiPartBinCueSize(bool value);
+    static Image::ImageType InferImageTypeFromImagePrefix(const char* prefix);
   private:
     bool Move(bool forward = true);
     bool FetchSizeFromCueFile();
+    static Image::ImageType inferImageTypeFromFileName(const char* filename);
     FsFile currentFile;
     FsFile root;
     char candidate[MAX_FILE_PATH + 1];

--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -62,11 +62,9 @@ namespace zuluide::images {
 	Defaults to true.
      **/
     void SetParseMultiPartBinCueSize(bool value);
-    static Image::ImageType InferImageTypeFromImagePrefix(const char* prefix);
   private:
     bool Move(bool forward = true);
     bool FetchSizeFromCueFile();
-    static Image::ImageType inferImageTypeFromFileName(const char* filename);
     FsFile currentFile;
     FsFile root;
     char candidate[MAX_FILE_PATH + 1];

--- a/lib/ZuluControl/src/images/image_iterator.cpp
+++ b/lib/ZuluControl/src/images/image_iterator.cpp
@@ -150,7 +150,7 @@ bool ImageIterator::Move(bool forward) {
       return false;
 
     curIdx = matchingIdx;
-    candidateImageType = inferImageTypeFromFileName(candidate);
+    candidateImageType = Image::InferImageTypeFromFileName(candidate);
     return true;
   }
   return false;
@@ -457,43 +457,4 @@ bool ImageIterator::FetchSizeFromCueFile() {
   candidateSizeInBytes = totalSize;
   file.close();
   return true;
-}
-
-Image::ImageType ImageIterator::InferImageTypeFromImagePrefix(const char* prefix) {
-  if (strncasecmp(prefix, "cdrm", sizeof("cdrm")) == 0) {
-    return Image::ImageType::cdrom;
-  } else if (strncasecmp(prefix, "zipd", sizeof("zipd")) == 0) {
-    return Image::ImageType::zip100;
-  } else if (strncasecmp(prefix, "z100", sizeof("z100")) == 0) {
-    return Image::ImageType::zip100;
-  } else if (strncasecmp(prefix, "z250", sizeof("z250")) == 0) {
-    return Image::ImageType::zip250;
-  } else if (strncasecmp(prefix, "remv", sizeof("remv")) == 0) {
-    return Image::ImageType::generic;
-  } else if (strncasecmp(prefix, "hddr", sizeof("hddr")) == 0) {
-    return Image::ImageType::generic;
-  } else {
-    return Image::ImageType::unknown;
-  }
-}
-
-Image::ImageType ImageIterator::inferImageTypeFromFileName(const char *filename) {
-  auto returnValue = Image::ImageType::unknown;
-  auto len = strnlen(filename, MAX_FILE_PATH);
-
-  if (len > 3) {
-    // Check the suffix to see if this is a cd-rom image type extension.
-    if (strncasecmp(filename + len - 4, ".iso", sizeof(".iso")) == 0) {
-      returnValue = Image::ImageType::cdrom;
-    } else {
-      // Check  prefix to see if this uses the ZuluIDE file-prefix format.
-      char *prefix = (char *)calloc(4, sizeof(char));
-      if (prefix) {
-        strncpy(prefix, filename, 4);
-        returnValue = ImageIterator::InferImageTypeFromImagePrefix(prefix);
-      }
-    }
-  }
-
-  return returnValue;
 }

--- a/lib/ZuluControl/src/images/image_iterator.cpp
+++ b/lib/ZuluControl/src/images/image_iterator.cpp
@@ -150,6 +150,7 @@ bool ImageIterator::Move(bool forward) {
       return false;
 
     curIdx = matchingIdx;
+    candidateImageType = inferImageTypeFromFileName(candidate);
     return true;
   }
   return false;
@@ -456,4 +457,43 @@ bool ImageIterator::FetchSizeFromCueFile() {
   candidateSizeInBytes = totalSize;
   file.close();
   return true;
+}
+
+Image::ImageType ImageIterator::InferImageTypeFromImagePrefix(const char* prefix) {
+  if (strncasecmp(prefix, "cdrm", sizeof("cdrm")) == 0) {
+    return Image::ImageType::cdrom;
+  } else if (strncasecmp(prefix, "zipd", sizeof("zipd")) == 0) {
+    return Image::ImageType::zip100;
+  } else if (strncasecmp(prefix, "z100", sizeof("z100")) == 0) {
+    return Image::ImageType::zip100;
+  } else if (strncasecmp(prefix, "z250", sizeof("z250")) == 0) {
+    return Image::ImageType::zip250;
+  } else if (strncasecmp(prefix, "remv", sizeof("remv")) == 0) {
+    return Image::ImageType::generic;
+  } else if (strncasecmp(prefix, "hddr", sizeof("hddr")) == 0) {
+    return Image::ImageType::generic;
+  } else {
+    return Image::ImageType::unknown;
+  }
+}
+
+Image::ImageType ImageIterator::inferImageTypeFromFileName(const char *filename) {
+  auto returnValue = Image::ImageType::unknown;
+  auto len = strnlen(filename, MAX_FILE_PATH);
+
+  if (len > 3) {
+    // Check the suffix to see if this is a cd-rom image type extension.
+    if (strncasecmp(filename + len - 4, ".iso", sizeof(".iso")) == 0) {
+      returnValue = Image::ImageType::cdrom;
+    } else {
+      // Check  prefix to see if this uses the ZuluIDE file-prefix format.
+      char *prefix = (char *)calloc(4, sizeof(char));
+      if (prefix) {
+        strncpy(prefix, filename, 4);
+        returnValue = ImageIterator::InferImageTypeFromImagePrefix(prefix);
+      }
+    }
+  }
+
+  return returnValue;
 }

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -237,41 +237,25 @@ void init_logfile()
 drive_type_t searchForDriveType() {
   zuluide::images::ImageIterator imgIter;
   imgIter.Reset();
-  while(imgIter.MoveNext()) {
+  while (imgIter.MoveNext()) {
     Image image = imgIter.Get();
 
-    switch (image.GetImageType()) {
-        case Image::ImageType::cdrom: {
-            return DRIVE_TYPE_CDROM;
-        }
+    if (image.GetImageType() == Image::ImageType::cdrom) {
+      return DRIVE_TYPE_CDROM;
     }
 
-    auto prefix = image.GetFilename().substr(0,4).c_str();
-    if (strncasecmp(prefix, "cdrm", sizeof("cdrm")) == 0) {
-      g_ide_imagefile.set_prefix(prefix);
-      return DRIVE_TYPE_CDROM;
-    } else if (strncasecmp(prefix, "zipd", sizeof("zipd")) == 0) {
-      g_ide_imagefile.set_prefix(prefix);
-      return DRIVE_TYPE_ZIP100;
-    } else if (strncasecmp(prefix, "z100", sizeof("z100")) == 0) {
-      g_ide_imagefile.set_prefix(prefix);
-      return DRIVE_TYPE_ZIP100;
-    } else if (strncasecmp(prefix, "z250", sizeof("z250")) == 0) {
-      g_ide_imagefile.set_prefix(prefix);
-      return DRIVE_TYPE_ZIP250;
-    } else if (strncasecmp(prefix, "remv", sizeof("remv")) == 0) {
-      g_ide_imagefile.set_prefix(prefix);
-      return DRIVE_TYPE_REMOVABLE;
-    } else if (strncasecmp(prefix, "hddr", sizeof("hddr")) == 0) {
-      g_ide_imagefile.set_prefix(prefix);
-      return DRIVE_TYPE_RIGID;
+    auto imageType = Image::InferImageTypeFromFileName(image.GetFilename().c_str());
+    if (imageType != Image::ImageType::unknown) {
+      imgIter.Cleanup();
+      g_ide_imagefile.set_prefix(Image::GetImagePrefix(imageType));
+      return Image::ToDriveType(imageType);
     }
   }
 
   imgIter.Cleanup();
 
   // If nothing is found, default to a CDROM.
-  return drive_type_t::DRIVE_TYPE_CDROM;
+  return DRIVE_TYPE_CDROM;
 }
 
 /***


### PR DESCRIPTION
Updated the logic to better infer the device type from the file type when not specified in the zuluide.ini. This helps startup time when an SD card has a large number of .iso images.