### PR TITLE
ZuluIDE defered ejection as ZIP drive

### DIFF
--- a/lib/ZuluControl/include/zuluide/control/display_state.h
+++ b/lib/ZuluControl/include/zuluide/control/display_state.h
@@ -25,23 +25,23 @@
 #include "status_state.h"
 #include "menu_state.h"
 #include "eject_state.h"
+#include "eject_prevented_state.h"
 #include "select_state.h"
-#include "new_image_state.h"
 #include "info_state.h"
 #include "splash_state.h"
 
 using namespace zuluide::images;
 
 namespace zuluide::control {
-  enum class Mode { Splash, Status, Menu, Eject, Select, Info, NewImage };
+  enum class Mode { Splash, Status, LoadDeferred, Menu, Eject, EjectPrevented, Select, Info };
 
   class DisplayState {
   public:
     DisplayState(const StatusState &state);
     DisplayState(MenuState &state);
     DisplayState(SelectState &state);
-    DisplayState(NewImageState &state);
     DisplayState(EjectState &state);
+    DisplayState(EjectPreventedState &state);
     DisplayState(InfoState &state);
     DisplayState(SplashState &state);
     DisplayState();
@@ -51,6 +51,7 @@ namespace zuluide::control {
     Mode GetCurrentMode() const;
     const MenuState& GetMenuState() const;
     const EjectState& GetEjectState() const;
+    const EjectPreventedState& GetEjectPreventedState() const;
     const SelectState& GetSelectState() const;
     const StatusState& GetStatusState() const;
     const InfoState& GetInfoState() const;
@@ -59,8 +60,8 @@ namespace zuluide::control {
     StatusState statusState;
     MenuState menuState;
     SelectState selectState;
-    NewImageState newImageState;
     EjectState ejectState;
+    EjectPreventedState ejectPreventedState;
     InfoState infoState;
     SplashState splashState;
   };

--- a/lib/ZuluControl/include/zuluide/control/eject_prevented_state.h
+++ b/lib/ZuluControl/include/zuluide/control/eject_prevented_state.h
@@ -25,15 +25,14 @@
 
 namespace zuluide::control {
 
-  class MenuState : public BaseState {
+  class EjectPreventedState : public BaseState {
   public:
-    enum class Entry { Eject, Select, Back, Info };
-    MenuState (Entry value = Entry::Eject);
-    MenuState (const MenuState& src);
+    enum class Entry { Back };
+    EjectPreventedState (Entry value = Entry::Back);
+    EjectPreventedState (const EjectPreventedState& src);
     Entry GetCurrentEntry () const;
-    void MoveToNextEntry();
-    void MoveToPreviousEntry();
-    MenuState& operator=(const MenuState& src);
+    void MoveToNextCurrentEntry();
+    EjectPreventedState& operator=(const EjectPreventedState& src);
   private:
     Entry currentEntry;
   };

--- a/lib/ZuluControl/include/zuluide/images/image.h
+++ b/lib/ZuluControl/include/zuluide/images/image.h
@@ -23,7 +23,7 @@
 
 #include <string>
 #include <stdint.h>
-#include <zuluide/ide_drive_type.h>>
+#include <zuluide/ide_drive_type.h>
 
 namespace zuluide::images {
 

--- a/lib/ZuluControl/include/zuluide/status/device_control_safe.h
+++ b/lib/ZuluControl/include/zuluide/status/device_control_safe.h
@@ -34,5 +34,7 @@ namespace zuluide::status {
   public:
     virtual void LoadImageSafe(zuluide::images::Image i) = 0;
     virtual void EjectImageSafe() = 0;
+    virtual bool IsPreventRemovable() = 0;
+    virtual bool IsDeferred() = 0;
   };    
 }

--- a/lib/ZuluControl/include/zuluide/status/system_status.h
+++ b/lib/ZuluControl/include/zuluide/status/system_status.h
@@ -53,6 +53,12 @@ namespace zuluide::status {
     bool IsCardPresent() const;
     void SetIsCardPresent(bool value);
 
+    bool IsPreventRemovable() const;
+    void SetIsPreventRemovable(bool disabled);
+
+    bool IsDeferred() const;
+    void SetIsDeferred(bool defer);
+
     std::string ToJson() const;
   private:
     std::unique_ptr<IDeviceStatus> primary;
@@ -60,5 +66,7 @@ namespace zuluide::status {
     std::unique_ptr<zuluide::images::Image> loadedImage;
     bool isPrimary;
     bool isCardPresent;
+    bool isPreventRemovable;
+    bool isDeferred;
   };
 }

--- a/lib/ZuluControl/src/control/control_interface.cpp
+++ b/lib/ZuluControl/src/control/control_interface.cpp
@@ -25,7 +25,6 @@
 #include "menu_controller.h"
 #include "select_controller.h"
 #include "status_controller.h"
-#include "new_controller.h"
 
 using namespace zuluide::control;
 
@@ -87,11 +86,6 @@ void ControlInterface::RotaryUpdate(int offset) {
     break;
   }
 
-  case Mode::NewImage: {
-    displayController->GetNewController().CreateAndSelect();
-    break;
-  }
-
   case Mode::Info: {
     int cur = offset;
     while (cur > 0) {
@@ -112,7 +106,7 @@ void ControlInterface::RotaryUpdate(int offset) {
 void ControlInterface::RotaryButtonPressed() {
   switch(currentDisplayMode) {
   case Mode::Status: {
-    displayController->GetStatusController().ChangeToMenu();
+      displayController->GetStatusController().ChangeToMenu();
     break;
   }
 
@@ -126,13 +120,13 @@ void ControlInterface::RotaryButtonPressed() {
     break;
   }
 
-  case Mode::Select: {
-    displayController->GetSelectController().SelectImage();
+  case Mode::EjectPrevented: {
+    displayController->GetEjectPreventedController().GoBack();
     break;
   }
 
-  case Mode::NewImage: {
-    displayController->GetNewController().CreateAndSelect();
+  case Mode::Select: {
+    displayController->GetSelectController().SelectImage();
     break;
   }
 
@@ -150,7 +144,7 @@ void ControlInterface::PrimaryButtonPressed() {
     break;
   }
   default:
-    break;      
+    break;
   }
 }
 
@@ -163,8 +157,11 @@ void ControlInterface::SecondaryButtonPressed() {
 
   case Mode::Status: {
     if (currentStatus.HasLoadedImage()) {
-      displayController->SetMode(Mode::Eject);
-    }
+      if(statusController && statusController->IsPreventRemovable())
+        displayController->SetMode(Mode::EjectPrevented);
+      else
+        displayController->SetMode(Mode::Eject);
+      }
     
     break;
   }

--- a/lib/ZuluControl/src/control/display_state.cpp
+++ b/lib/ZuluControl/src/control/display_state.cpp
@@ -38,11 +38,6 @@ DisplayState::DisplayState(SelectState &state) :
   selectState(state)
 {}
 
-DisplayState::DisplayState(NewImageState &state) :
-  currentMode(Mode::NewImage),
-  newImageState(state)
-{}
-
 DisplayState::DisplayState() :
   currentMode(Mode::Splash),
   splashState(SplashState())
@@ -59,15 +54,20 @@ DisplayState::DisplayState(SplashState& state) :
 {}
 
 
+DisplayState::DisplayState(EjectPreventedState& state) :
+  currentMode(Mode::EjectPrevented),
+  ejectPreventedState(state)
+{}
+
 DisplayState::DisplayState(const DisplayState& state) :
   currentMode(state.currentMode),
   statusState(state.statusState),
   menuState(state.menuState),
   selectState(state.selectState),
-  newImageState(state.newImageState),
   ejectState(state.ejectState),
   infoState(state.infoState),
-  splashState(state.splashState)
+  splashState(state.splashState),
+  ejectPreventedState(state.ejectPreventedState)
 {}
 
 DisplayState& DisplayState::operator=(DisplayState&& src) {
@@ -75,8 +75,8 @@ DisplayState& DisplayState::operator=(DisplayState&& src) {
   statusState = src.statusState;
   menuState = std::move(src.menuState);
   selectState = std::move(src.selectState);
-  newImageState = std::move(src.newImageState);
   ejectState = std::move(src.ejectState);
+  ejectPreventedState = std::move(src.ejectPreventedState);
   infoState = std::move(src.infoState);
   splashState = std::move(src.splashState);
   return *this;
@@ -88,9 +88,9 @@ DisplayState::DisplayState(DisplayState&& src) :
   statusState = std::move(src.statusState);
   menuState = std::move(src.menuState);
   selectState = std::move(src.selectState);
-  newImageState = std::move(src.newImageState);
   ejectState = std::move(src.ejectState);
   splashState = std::move(src.splashState);
+  ejectPreventedState = std::move(src.ejectPreventedState);
 }
 
 DisplayState::DisplayState(InfoState &state) :
@@ -108,6 +108,11 @@ const MenuState& DisplayState::GetMenuState() const {
 const EjectState& DisplayState::GetEjectState() const {
   return ejectState;
 }
+
+const EjectPreventedState& DisplayState::GetEjectPreventedState() const {
+  return ejectPreventedState;
+}
+
 
 const SelectState& DisplayState::GetSelectState() const {
   return selectState;

--- a/lib/ZuluControl/src/control/eject_prevented_controller.cpp
+++ b/lib/ZuluControl/src/control/eject_prevented_controller.cpp
@@ -19,22 +19,25 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-#pragma once
+#include "eject_prevented_controller.h"
+#include "std_display_controller.h"
 
-#include "base_state.h"
+using namespace zuluide::control;
 
-namespace zuluide::control {
+EjectPreventedController::EjectPreventedController(StdDisplayController* cntrlr, zuluide::status::DeviceControlSafe* statCtrlr) :
+  UIControllerBase(cntrlr), statusController(statCtrlr) {
+}
 
-  class NewImageState : public BaseState {
-  public:
-    NewImageState (int imgIndex = 0);
-    NewImageState (const NewImageState& src);
-    int GetImageIndex () const;
-    NewImageState& operator++(int);
-    NewImageState& operator--(int);
-    NewImageState& operator=(const NewImageState& src);
-  private:
-    int imageIndex;
-  };
-  
+void EjectPreventedController::GoBack() {
+  controller->SetMode(Mode::Status);
+}
+
+void EjectPreventedController::SetState(const EjectPreventedState newState) {
+  state = newState;
+}
+
+
+DisplayState EjectPreventedController::Reset() {
+  state = EjectPreventedState();
+  return DisplayState(state);
 }

--- a/lib/ZuluControl/src/control/eject_prevented_controller.h
+++ b/lib/ZuluControl/src/control/eject_prevented_controller.h
@@ -19,39 +19,25 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-#include "new_controller.h"
-#include "std_display_controller.h"
+#pragma once
 
-using namespace zuluide::control;
+#include <zuluide/status/device_control_safe.h>
+#include <zuluide/control/display_state.h>
+#include "ui_controller_base.h"
 
-NewController::NewController(StdDisplayController* cntrlr, zuluide::status::StatusController* statCtrlr) :
-  UIControllerBase(cntrlr), statusController(statCtrlr) {
-}
-
-void NewController::IncrementImageIndex() {
-  state++;
-    // TODO: Check image indices
-  controller->UpdateState(state);
-}
-
-void NewController::DecreaseImageIndex() {
-  state--;
-    // TODO: Check image indices
-  controller->UpdateState(state);
-}
-
-void NewController::ResetImageIndex() {
-  state = NewImageState(0);
-    // TODO: Check image indices
-  controller->UpdateState(state);
-}
-
-void NewController::CreateAndSelect() {
-  // TODO: Create image
-  controller->SetMode(Mode::Status);
-}
-
-DisplayState NewController::Reset() {
-  state = NewImageState();
-  return DisplayState(state);
+namespace zuluide::control {
+  class StdDisplayController;
+  /**
+     Controls state when the UI is showing the menu.
+   */
+  class EjectPreventedController : public UIControllerBase {
+  public:
+    EjectPreventedController(StdDisplayController* cntrlr, zuluide::status::DeviceControlSafe* statCtrlr);
+    void GoBack();
+    void SetState(const EjectPreventedState newState);
+    virtual DisplayState Reset();
+  private:
+    EjectPreventedState state;
+    zuluide::status::DeviceControlSafe *statusController;
+  };
 }

--- a/lib/ZuluControl/src/control/eject_prevented_state.cpp
+++ b/lib/ZuluControl/src/control/eject_prevented_state.cpp
@@ -19,29 +19,23 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-#include <zuluide/control/display_state.h>
+#include <zuluide/control/eject_prevented_state.h>
 
 using namespace zuluide::control;
 
-NewImageState::NewImageState (int imgIndex) : imageIndex (imgIndex) {}
-
-NewImageState::NewImageState (const NewImageState& src) : imageIndex(src.imageIndex) {}
-
-int NewImageState::GetImageIndex () const {
-  return imageIndex;
+EjectPreventedState::EjectPreventedState (Entry value)
+  : currentEntry(value) {
 }
 
-NewImageState& NewImageState::operator=(const NewImageState& src) {
-  imageIndex = src.imageIndex;
-  return *this;
+EjectPreventedState::EjectPreventedState (const EjectPreventedState& src)
+  : currentEntry(src.currentEntry) {
 }
 
-NewImageState& NewImageState::operator++(int) {
-  imageIndex++;
-  return *this;
+EjectPreventedState::Entry EjectPreventedState::GetCurrentEntry () const {
+  return currentEntry;
 }
 
-NewImageState& NewImageState::operator--(int) {
-  imageIndex--;
+EjectPreventedState& EjectPreventedState::operator=(const EjectPreventedState& src) {
+  currentEntry = src.currentEntry;
   return *this;
 }

--- a/lib/ZuluControl/src/control/menu_controller.cpp
+++ b/lib/ZuluControl/src/control/menu_controller.cpp
@@ -24,7 +24,7 @@
 
 using namespace zuluide::control;
 
-MenuController::MenuController(StdDisplayController* cntrlr) : UIControllerBase(cntrlr) {
+MenuController::MenuController(StdDisplayController* cntrlr, zuluide::status::DeviceControlSafe* statCtrlr) : UIControllerBase(cntrlr), statusController (statCtrlr) {
 }
 
 void MenuController::MoveToNextEntry() {
@@ -40,7 +40,10 @@ void MenuController::MoveToPreviousEntry() {
 void MenuController::ChangeToSelectedEntry() {
   switch (state.GetCurrentEntry()) {
   case MenuState::Entry::Eject: {
-    controller->SetMode(Mode::Eject);
+    if (statusController->IsPreventRemovable())
+      controller->SetMode(Mode::EjectPrevented);
+    else
+      controller->SetMode(Mode::Eject);
     break;
   }
     
@@ -53,12 +56,7 @@ void MenuController::ChangeToSelectedEntry() {
     controller->SetMode(Mode::Info);
     break;
   }
-    
-  case MenuState::Entry::New: {
-    controller->SetMode(Mode::NewImage);
-    break;
-  }
-    
+
   case MenuState::Entry::Back: {
     controller->SetMode(Mode::Status);
     break;

--- a/lib/ZuluControl/src/control/menu_controller.h
+++ b/lib/ZuluControl/src/control/menu_controller.h
@@ -23,6 +23,7 @@
 
 #include <zuluide/control/display_state.h>
 #include "ui_controller_base.h"
+#include <status/status_controller.h>
 
 namespace zuluide::control {
   class StdDisplayController;
@@ -31,12 +32,13 @@ namespace zuluide::control {
    */
   class MenuController : public UIControllerBase {
   public:
-    MenuController(StdDisplayController* cntrlr);
+    MenuController(StdDisplayController* cntrlr, zuluide::status::DeviceControlSafe* statCtrlr);
     void MoveToNextEntry();
     void MoveToPreviousEntry();
     void ChangeToSelectedEntry();
     virtual DisplayState Reset();
   private:
+    zuluide::status::DeviceControlSafe *statusController;
     MenuState state;
   };
 }

--- a/lib/ZuluControl/src/control/menu_state.cpp
+++ b/lib/ZuluControl/src/control/menu_state.cpp
@@ -83,4 +83,3 @@ void MenuState::MoveToPreviousEntry() {
   }
   }
 }
-

--- a/lib/ZuluControl/src/control/status_controller.h
+++ b/lib/ZuluControl/src/control/status_controller.h
@@ -37,6 +37,7 @@ namespace zuluide::control {
     void ResetImageNameOffset();
     void ChangeToMenu();
     virtual DisplayState Reset();
+    void ChangeToMenuPreventRem();
   private:
     StatusState state;
   };

--- a/lib/ZuluControl/src/control/std_display_controller.cpp
+++ b/lib/ZuluControl/src/control/std_display_controller.cpp
@@ -20,7 +20,6 @@
 **/
 
 #include "std_display_controller.h"
-#include "new_controller.h"
 #include "eject_controller.h"
 #include "menu_controller.h"
 #include "info_controller.h"
@@ -49,12 +48,15 @@ UIControllerBase* StdDisplayController::getControllerByMode(const Mode mode) {
     return &ejectController;
   }
 
+  case Mode::EjectPrevented: {
+    EjectPreventedState empty;
+    UpdateState(empty);
+    ejectPreventedController.SetState(empty);
+    return &ejectPreventedController;
+  }
+    
   case Mode::Select: {
     return &selectController;
-  }
-
-  case Mode::NewImage: {
-    return &newController;
   }
 
   case Mode::Info: {
@@ -97,14 +99,14 @@ void StdDisplayController::UpdateState(SelectState& newState)
   notifyObservers();
 }
 
-void StdDisplayController::UpdateState(NewImageState& newState)
+void StdDisplayController::UpdateState(EjectState& newState)
 {
   // Copy the new state into a new memory location.
   currentState = std::move(DisplayState(newState));
   notifyObservers();
 }
 
-void StdDisplayController::UpdateState(EjectState& newState)
+void StdDisplayController::UpdateState(EjectPreventedState& newState)
 {
   // Copy the new state into a new memory location.
   currentState = std::move(DisplayState(newState));
@@ -147,12 +149,12 @@ EjectController& StdDisplayController::GetEjectController() {
   return ejectController;
 }
 
-SelectController& StdDisplayController::GetSelectController() {
-  return selectController;
+EjectPreventedController& StdDisplayController::GetEjectPreventedController() {
+  return ejectPreventedController;
 }
 
-NewController& StdDisplayController::GetNewController() {
-  return newController;
+SelectController& StdDisplayController::GetSelectController() {
+  return selectController;
 }
 
 InfoController& StdDisplayController::GetInfoController() {
@@ -165,10 +167,10 @@ SplashController& StdDisplayController::GetSplashController() {
 
 StdDisplayController::StdDisplayController(zuluide::status::StatusController* statCtrlr) : statController(statCtrlr),
 											   current(NULL),
-											   menuController(this),
+											   menuController(this, statController),
 											   ejectController(this, statController),
+                         ejectPreventedController(this, statController),
 											   selectController(this, statController),
-											   newController(this, statController),
 											   infoController(this),
 											   splashController(this),
 											   statusController(this) {

--- a/lib/ZuluControl/src/control/std_display_controller.h
+++ b/lib/ZuluControl/src/control/std_display_controller.h
@@ -29,8 +29,8 @@
 #include "status_controller.h"
 #include "menu_controller.h"
 #include "eject_controller.h"
+#include "eject_prevented_controller.h"
 #include "select_controller.h"
-#include "new_controller.h"
 #include "info_controller.h"
 #include "splash_controller.h"
 
@@ -45,18 +45,18 @@ namespace zuluide::control {
     void AddObserver(std::function<void(const DisplayState& current)> callback);
     Mode GetMode() const;
     zuluide::status::StatusController& GetStatController();
-    zuluide::control::StatusController& GetStatusController();
+    StatusController& GetStatusController();
     MenuController& GetMenuController();
     EjectController& GetEjectController();
+    EjectPreventedController& GetEjectPreventedController();
     SelectController& GetSelectController();
-    NewController& GetNewController();
     InfoController& GetInfoController();
     SplashController& GetSplashController();
     void UpdateState(StatusState& newState);
     void UpdateState(MenuState& newState);
     void UpdateState(SelectState& newState);
     void UpdateState(EjectState& newState);
-    void UpdateState(NewImageState& newState);
+    void UpdateState(EjectPreventedState& newState);
     void UpdateState(InfoState& newState);
     void UpdateState(SplashState& newState);
     void SetMode(Mode value);
@@ -66,13 +66,13 @@ namespace zuluide::control {
     void notifyObservers();
     std::vector<std::function<void(const DisplayState& current)>> observers;
     DisplayState currentState;
-    zuluide::control::StatusController statusController;
+    StatusController statusController;
     zuluide::status::StatusController* statController;
     UIControllerBase* current;
     MenuController menuController;
     EjectController ejectController;
+    EjectPreventedController ejectPreventedController;
     SelectController selectController;
-    NewController newController;
     InfoController infoController;
     SplashController splashController;
     UIControllerBase* getControllerByMode(const Mode mode);

--- a/lib/ZuluControl/src/status/status_controller.cpp
+++ b/lib/ZuluControl/src/status/status_controller.cpp
@@ -118,3 +118,26 @@ void StatusController::SetIsCardPresent(bool value) {
   
   notifyObservers();
 }
+
+
+void StatusController::SetIsPreventRemovable(bool prevent)
+{
+  status.SetIsPreventRemovable(prevent);
+}
+
+bool StatusController::IsPreventRemovable()
+{
+  return status.IsPreventRemovable();
+}
+
+void StatusController::SetIsDeferred(bool defer)
+{
+  status.SetIsDeferred(defer);
+  if (!defer)
+    notifyObservers();
+}
+
+bool StatusController::IsDeferred()
+{
+  return status.IsDeferred();
+}

--- a/lib/ZuluControl/src/status/status_controller.h
+++ b/lib/ZuluControl/src/status/status_controller.h
@@ -51,10 +51,14 @@ namespace zuluide::status {
     void SetFirmwareVersion(std::string firmwareVersion);
     const SystemStatus& GetStatus();
     void Reset();
-    virtual void LoadImageSafe(zuluide::images::Image i);
-    virtual void EjectImageSafe();
+    virtual void LoadImageSafe(zuluide::images::Image i) override;
+    virtual void EjectImageSafe() override;
+    virtual bool IsPreventRemovable() override;
+    virtual bool IsDeferred() override;
     void ProcessUpdates();
     void SetIsCardPresent(bool value);
+    void SetIsPreventRemovable(bool prevent);
+    void SetIsDeferred(bool defer);
   private:
     bool isUpdating;
     void notifyObservers();
@@ -65,7 +69,7 @@ namespace zuluide::status {
      **/
     std::vector<queue_t*> observerQueues;
     /***
-        Stores updates that come from another thread. These are processed through calss to ProcessUpdates.
+        Stores updates that come from another thread. These are processed through class to ProcessUpdates.
      **/
     queue_t updateQueue;
 

--- a/lib/ZuluControl/src/status/system_status.cpp
+++ b/lib/ZuluControl/src/status/system_status.cpp
@@ -30,7 +30,7 @@ SystemStatus::SystemStatus()
 }
 
 SystemStatus::SystemStatus(const SystemStatus& src)
-  : firmwareVersion(src.firmwareVersion), isCardPresent(src.isCardPresent), isPrimary(src.isPrimary)
+  : firmwareVersion(src.firmwareVersion), isCardPresent(src.isCardPresent), isPrimary(src.isPrimary), isPreventRemovable(src.isPreventRemovable), isDeferred(src.isDeferred)
 {
   if (src.primary) {
     primary = std::move(src.primary->Clone());
@@ -48,6 +48,8 @@ SystemStatus::SystemStatus(SystemStatus&& src)
   loadedImage = std::move(src.loadedImage);
   isCardPresent = src.isCardPresent;
   isPrimary = src.isPrimary;
+  isPreventRemovable = src.isPreventRemovable;
+  isDeferred = src.isDeferred;
 }
 
 SystemStatus& SystemStatus::operator= (SystemStatus&& src) {
@@ -56,6 +58,8 @@ SystemStatus& SystemStatus::operator= (SystemStatus&& src) {
   loadedImage = std::move(src.loadedImage);
   isCardPresent = src.isCardPresent;
   isPrimary = src.isPrimary;
+  isPreventRemovable = src.isPreventRemovable;  
+  isDeferred = src.isDeferred;
   return *this;
 }
 
@@ -72,6 +76,8 @@ SystemStatus& SystemStatus::operator= (const SystemStatus& src) {
 
   isCardPresent = src.isCardPresent;
   isPrimary = src.isPrimary;
+  isPreventRemovable = src.isPreventRemovable;
+  isDeferred = src.isDeferred;
 
   return *this;
 }
@@ -132,6 +138,21 @@ void SystemStatus::SetIsCardPresent(bool value) {
   isCardPresent = value;
 }
 
+bool SystemStatus::IsPreventRemovable() const {
+  return isPreventRemovable;
+}
+
+void SystemStatus::SetIsPreventRemovable(bool prevent){
+  isPreventRemovable = prevent;
+}
+
+bool SystemStatus::IsDeferred() const {
+  return isDeferred;
+}
+void SystemStatus::SetIsDeferred(bool defer){
+  isDeferred = defer;
+}
+
 static const char* toString(bool value) {
   if (value) {
     return "true";
@@ -166,6 +187,10 @@ std::string SystemStatus::ToJson() const {
   outputField(output, "isPrimary", isPrimary);
   output.append(",");
   outputField(output, "isCardPresent", isCardPresent);
+  output.append(",");
+  outputField(output, "isPreventRemovable", isPreventRemovable),
+  output.append(",");
+  outputField(output, "isDeferred", isDeferred),
   output.append(",");
   outputField(output, "fwVer", firmwareVersion);
   if (loadedImage) {

--- a/lib/ZuluIDE_platform_RP2040/display/display_ssd1306.cpp
+++ b/lib/ZuluIDE_platform_RP2040/display/display_ssd1306.cpp
@@ -84,8 +84,16 @@ void DisplaySSD1306::HandleUpdate(const zuluide::control::DisplayState& current)
       currentWidget = std::make_unique<zuluide::StatusWidget>(&graph, Rectangle{{0,0}, {WIDTH, HEIGHT}}, wBounds);
       break;
     }
+    case zuluide::control::Mode::LoadDeferred: {
+      currentWidget = std::make_unique<zuluide::StatusWidget>(&graph, Rectangle{{0,0}, {WIDTH, HEIGHT}}, wBounds);
+      break;
+    }
+
     case zuluide::control::Mode::Eject:
       currentWidget = std::make_unique<zuluide::EjectWidget>(&graph, Rectangle{{0,0}, {WIDTH, HEIGHT}}, wBounds);
+      break;
+    case zuluide::control::Mode::EjectPrevented:
+      currentWidget = std::make_unique<zuluide::EjectPreventedWidget>(&graph, Rectangle{{0,0}, {WIDTH, HEIGHT}}, wBounds);
       break;
     case zuluide::control::Mode::Info: {
       currentWidget = std::make_unique<zuluide::InfoWidget>(&graph, Rectangle{{0,0}, {WIDTH, HEIGHT}}, wBounds);

--- a/lib/ZuluIDE_platform_RP2040/display/display_ssd1306.h
+++ b/lib/ZuluIDE_platform_RP2040/display/display_ssd1306.h
@@ -31,6 +31,7 @@
 #include "status_widget.h"
 #include "info_widget.h"
 #include "eject_widget.h"
+#include "eject_prevented_widget.h"
 #include "menu_widget.h"
 #include "select_widget.h"
 #include "splash_widget.h"

--- a/lib/ZuluIDE_platform_RP2040/display/eject_prevented_widget.cpp
+++ b/lib/ZuluIDE_platform_RP2040/display/eject_prevented_widget.cpp
@@ -19,27 +19,27 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-#pragma once
+#include "eject_prevented_widget.h"
+#include "ZuluIDE_log.h"
 
-#include <zuluide/control/display_state.h>
-#include "../status/status_controller.h"
-#include "ui_controller_base.h"
+#define EJECT_MENU_TEXT "-- Host Eject Only --"
+#define MENU_OFFSET 1
 
-namespace zuluide::control {
-  class StdDisplayController;
-  /**
-     Controls state when the UI is creating a new image.
-   */
-  class NewController : public UIControllerBase {
-  public:
-    NewController(StdDisplayController* cntrlr, zuluide::status::StatusController* statCtrlr);
-    void IncrementImageIndex();
-    void DecreaseImageIndex();
-    void ResetImageIndex();
-    void CreateAndSelect();
-    virtual DisplayState Reset();
-  private:
-    NewImageState state;
-    zuluide::status::StatusController *statusController;
-  };
+using namespace zuluide;
+
+EjectPreventedWidget::EjectPreventedWidget(Adafruit_SSD1306 *g, Rectangle b, Size cb) :
+  Widget(g, b)
+{
+  charBounds = cb;
+}
+
+void EjectPreventedWidget::Display () {
+  graph->setTextColor(WHITE, BLACK);
+
+  DrawCenteredTextAt (EJECT_MENU_TEXT, 0);
+
+  const char* selectMenuText = " Back ";
+  graph->setTextColor(BLACK, WHITE);
+  DrawCenteredTextAt (selectMenuText, 16 + MENU_OFFSET);
+  graph->setTextColor(WHITE, BLACK);
 }

--- a/lib/ZuluIDE_platform_RP2040/display/eject_prevented_widget.h
+++ b/lib/ZuluIDE_platform_RP2040/display/eject_prevented_widget.h
@@ -21,21 +21,15 @@
 
 #pragma once
 
-#include "base_state.h"
+#include "widget.h"
+#include "scrolling_text.h"
 
-namespace zuluide::control {
-
-  class MenuState : public BaseState {
+namespace zuluide {
+  class EjectPreventedWidget : public Widget {
   public:
-    enum class Entry { Eject, Select, Back, Info };
-    MenuState (Entry value = Entry::Eject);
-    MenuState (const MenuState& src);
-    Entry GetCurrentEntry () const;
-    void MoveToNextEntry();
-    void MoveToPreviousEntry();
-    MenuState& operator=(const MenuState& src);
+    EjectPreventedWidget(Adafruit_SSD1306 *graph, Rectangle bounds, Size charBounds);
+    virtual void Display ();
   private:
-    Entry currentEntry;
+    Size charBounds;
   };
-  
 }

--- a/lib/ZuluIDE_platform_RP2040/display/menu_widget.cpp
+++ b/lib/ZuluIDE_platform_RP2040/display/menu_widget.cpp
@@ -84,8 +84,6 @@ static const char* toString(const zuluide::control::MenuState::Entry value) {
     return "[ EJECT ]";
   case zuluide::control::MenuState::Entry::Select:
     return "[ SELECT ]";
-  case zuluide::control::MenuState::Entry::New:
-    return "[ NEW ]";
   case zuluide::control::MenuState::Entry::Back:
     return "[ BACK ]";
   case zuluide::control::MenuState::Entry::Info:

--- a/lib/ZuluIDE_platform_RP2040/display/status_widget.cpp
+++ b/lib/ZuluIDE_platform_RP2040/display/status_widget.cpp
@@ -28,7 +28,8 @@ using namespace zuluide;
 
 StatusWidget::StatusWidget(Adafruit_SSD1306 *g, Rectangle b, Size cb) :
   Widget(g, b),
-  imagename {g, b.MakeCentered({b.size.width, cb.height})}
+  imagename {g, b.MakeCentered({b.size.width, cb.height})},
+  deferred_load {g, b.MakeCenteredAt(24, {b.size.width, cb.height})}
 {
   charBounds = cb;
 }
@@ -37,6 +38,9 @@ void StatusWidget::Update (const zuluide::status::SystemStatus& status) {
   if (!currentSysStatus || !currentSysStatus->LoadedImagesAreEqual(status)) {
     const char* filename = status.HasLoadedImage() ? status.GetLoadedImage().GetFilename().c_str() : "";
     imagename.SetToDisplay(filename);
+
+    const char* message = status.IsDeferred() ? "To load image, eject device from host system" : "";
+    deferred_load.SetToDisplay(message);
   }
 
   Widget::Update(status);
@@ -44,11 +48,14 @@ void StatusWidget::Update (const zuluide::status::SystemStatus& status) {
 
 void StatusWidget::Update (const zuluide::control::DisplayState &disp) {
   imagename.Reset();
+  deferred_load.Reset();
   Widget::Update(disp);
 }
 
 bool StatusWidget::Refresh () {
-  return imagename.CheckAndUpdateScrolling(get_absolute_time());
+  bool update = imagename.CheckAndUpdateScrolling(get_absolute_time());
+  update = deferred_load.CheckAndUpdateScrolling(get_absolute_time()) || update;
+  return update;
 }
 
 void StatusWidget::Display () {
@@ -59,6 +66,7 @@ void StatusWidget::Display () {
   }
   if (currentSysStatus->HasLoadedImage()) {
     imagename.Display();
+    deferred_load.Display();
 
     auto size = currentSysStatus->GetLoadedImage().GetFileSizeBytes();
     if (size != 0) {
@@ -70,6 +78,7 @@ void StatusWidget::Display () {
     // Draw the icon.
     auto dev_icon = currentSysStatus->GetDeviceType() == drive_type_t::DRIVE_TYPE_ZIP100 ? zipdrive_loaded : cdrom_loaded;
     graph->drawBitmap(0, 0, dev_icon, 18, 9, WHITE);
+
   } else if (!currentSysStatus->IsCardPresent()) {
     auto dev_icon = currentSysStatus->GetDeviceType() == drive_type_t::DRIVE_TYPE_ZIP100 ? zipdrive_empty : cdrom_empty;
     graph->drawBitmap(0, 0, dev_icon, 18, 9, WHITE);

--- a/lib/ZuluIDE_platform_RP2040/display/status_widget.h
+++ b/lib/ZuluIDE_platform_RP2040/display/status_widget.h
@@ -34,6 +34,7 @@ namespace zuluide {
     virtual void Update (const zuluide::control::DisplayState &disp);
   private:
     ScrollingText imagename;
+    ScrollingText deferred_load;
     Size charBounds;
     uint8_t cdrom_loaded[27] = {
 	0x01, 0xc0, 0x00, 0x1f, 0xfc, 0x00, 0x7f, 0xff, 0x00, 0x7f, 0x7f, 0x00, 0xfe, 0x3f, 0x80, 0x7f, 

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,7 +27,7 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.04.10"
+#define FW_VER_NUM      "2025.04.22"
 #define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,8 +27,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.04.04"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2025.04.10"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -797,13 +797,9 @@ bool IDEATAPIDevice::atapi_cmd_ok()
 
 bool IDEATAPIDevice::atapi_test_unit_ready(const uint8_t *cmd)
 {
-    if (m_devinfo.removable && m_removable.ejected)
+    if (m_devinfo.removable && m_removable.ejected && m_removable.reinsert_media_after_eject && check_time_after_eject())
     {
-        if (m_removable.reinsert_media_after_eject && check_time_after_eject())
-        {
-            insert_next_media(m_image);
-        }
-        return atapi_cmd_not_ready_error();
+        insert_next_media(m_image);
     }
     else if (!has_image())
     {
@@ -872,6 +868,7 @@ bool IDEATAPIDevice::atapi_prevent_allow_removal(const uint8_t *cmd)
 
         // We can't actually prevent SD card from being removed
         dbgmsg("-- Host requested prevent=", (int)m_removable.prevent_removable, " persistent=", (int)m_removable.prevent_persistent);
+        g_StatusController.SetIsPreventRemovable(m_removable.prevent_removable);
     }
     return atapi_cmd_ok();
 }

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -136,6 +136,7 @@ protected:
         bool prevent_removable;
         bool prevent_persistent;
         bool ignore_prevent_removal;
+        bool receiving_event_status_notifications;
         uint32_t eject_time;
         bool is_load_deferred;
         char deferred_image_name[MAX_FILE_PATH+1];
@@ -222,6 +223,4 @@ protected:
     // Set not ready if enabled via config ini
     virtual void set_not_ready(bool not_ready);
 
-    // Wait a moment after ejection before reinsertion
-    bool check_time_after_eject();
 };

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -25,6 +25,7 @@
 
 #include "ide_protocol.h"
 #include "ide_imagefile.h"
+#include "ZuluIDE_config.h"
 #include <stddef.h>
 
 #define ATAPI_AUDIO_CD_SECTOR_SIZE 2352
@@ -69,6 +70,9 @@ public:
     virtual void insert_media(IDEImage *image = nullptr) override;
 
     virtual void insert_next_media(IDEImage *image = nullptr) override;
+
+    virtual inline bool set_load_deferred(const char* image_name) override {return false;}
+    virtual inline bool is_load_deferred() override {return false;}
 
     virtual void sd_card_inserted() override;
 
@@ -133,6 +137,8 @@ protected:
         bool prevent_persistent;
         bool ignore_prevent_removal;
         uint32_t eject_time;
+        bool is_load_deferred;
+        char deferred_image_name[MAX_FILE_PATH+1];
     } m_removable;
 
     // Buffer used for responses, ide_phy code benefits from this being aligned to 32 bits

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -82,6 +82,10 @@ public:
     // For removable media devices - insert next
     virtual void insert_next_media(IDEImage *image = nullptr) = 0;
 
+    // Deferred loading status
+    virtual bool set_load_deferred(const char* image_name) = 0;
+    virtual bool is_load_deferred() = 0;
+
 
 protected:
     struct {

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -62,14 +62,16 @@ public:
 
     virtual void fill_device_signature(ide_registers_t *regs) override;
 
-    virtual void eject_button_poll(bool immediate) {;}
+    virtual inline void eject_button_poll(bool immediate) override {;}
 
-    virtual void sd_card_inserted() {;}
+    virtual inline void sd_card_inserted() override {;}
 
-    virtual void insert_media(IDEImage *image = nullptr) {;}
+    virtual inline void insert_media(IDEImage *image = nullptr) override {;}
 
-    virtual void insert_next_media(IDEImage *image = nullptr) {;}
+    virtual inline void insert_next_media(IDEImage *image = nullptr) override {;}
 
+    virtual inline bool set_load_deferred(const char* image_name) override {return false;}
+    virtual inline bool is_load_deferred() override {return false;}
 protected:
     IDEImage *m_image;
 

--- a/src/ide_zipdrive.h
+++ b/src/ide_zipdrive.h
@@ -40,7 +40,14 @@ public:
 
     virtual bool disables_iordy() override { return true; }
 
+    virtual void eject_media() override;
+
     virtual void button_eject_media() override;
+
+    virtual void insert_media(IDEImage *image = nullptr) override;
+
+    virtual bool set_load_deferred(const char* image_name) override;
+    virtual bool is_load_deferred() override;
 
 protected:
     virtual bool cmd_identify_packet_device(ide_registers_t *regs) override;
@@ -52,6 +59,7 @@ protected:
     virtual bool atapi_read_format_capacities(const uint8_t *cmd);
     virtual bool atapi_verify(const uint8_t *cmd);
     virtual bool atapi_inquiry(const uint8_t *cmd) override;
+    virtual bool atapi_start_stop_unit(const uint8_t *cmd) override;
     virtual bool atapi_zip_disk_0x06(const uint8_t *cmd);
     virtual bool atapi_zip_disk_0x0D(const uint8_t *cmd);
 

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -6,7 +6,7 @@
 # enable_usb_mass_storage = 0 # Disabled by default, set to 1 to enable access via USB mass storage
 
 # eject_button = 1 # bit field bit 0 = GPIO_11 (default),  bit 1 = GPIO_14
-# ignore_prevent_removal = 0 # Set to 1 to ignore the host's ability to block ejection
+# ignore_prevent_removal = 1 # Set to 0 to respect the host's ability to block ejection
 # has_drive1 = 0         # Force secondary drive detection result
 
 # max_udma = 0           # Maximum UDMA mode to use, -1 to disable UDMA


### PR DESCRIPTION
A Zip drive is able to tell the host that the eject button has been pressed even if the drive ejection is locked by the SCSI command "prevent allow medium removal". The Roland SP-808 uses this to prompt the use to save their song before ejecting the drive.

This change allows both the controller board and the eject button to emulate this zip drive feature.
The setting in `zuluide.ini` under `[IDE]` `ignore_prevent_removal = 0` must be set for it to work properly.