### PR TITLE
Hide controller board splash screen after 3 secs

### DIFF
--- a/lib/ZuluControl/src/control/std_display_controller.cpp
+++ b/lib/ZuluControl/src/control/std_display_controller.cpp
@@ -68,6 +68,11 @@ UIControllerBase* StdDisplayController::getControllerByMode(const Mode mode) {
   }
 }
 
+Mode StdDisplayController::GetMode() const
+{
+  return currentState.GetCurrentMode();
+}
+
 void StdDisplayController::SetMode(Mode newMode)
 {
   current = getControllerByMode(newMode);

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -327,8 +327,6 @@ void platform_set_display_controller(zuluide::Observable<zuluide::control::Displ
 
 void platform_set_input_interface(zuluide::control::InputReceiver* inputReceiver) {
   logmsg("Initialized platform controller with input receiver.");
-  uint8_t ticks = ini_getl("UI", "ticks", 1, CONFIGFILE);
-  g_rotary_input.SetSensitivity(ticks);
   g_rotary_input.SetReceiver(inputReceiver);
   g_rotary_input.StartSendingEvents();
 }
@@ -888,7 +886,7 @@ void platform_poll()
     static uint32_t prev_poll_time;
     static bool license_log_done = false;
     static bool license_from_sd_done = false;
-
+    static bool updated_controller_board = false;
     // No point polling the USB hardware more often than once per millisecond
     uint32_t time_now = millis();
     if (time_now == prev_poll_time)
@@ -939,6 +937,14 @@ void platform_poll()
         }
 
         license_log_done = true;
+    }
+
+    // update settings for the controller board the first time SD is read
+    if (g_sdcard_present && !updated_controller_board)
+    {
+        uint8_t ticks = ini_getl("UI", "ticks", 1, CONFIGFILE);
+        g_rotary_input.SetSensitivity(ticks);
+        updated_controller_board = true;
     }
 
     // Monitor supply voltage and process USB events

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -542,6 +542,8 @@ void zuluide_init(void)
 void zuluide_main_loop(void)
 {
     static uint32_t sd_card_check_time;
+    static uint32_t splash_check_time;
+    static bool splash_over = false;
     static bool first_loop = true;
 
     if (first_loop)
@@ -549,6 +551,7 @@ void zuluide_main_loop(void)
         // Give time for basic initialization to run
         // before checking SD card
         sd_card_check_time = millis() + 1000;
+        splash_check_time = millis();
         first_loop = false;
     }
     platform_reset_watchdog();
@@ -556,7 +559,19 @@ void zuluide_main_loop(void)
     g_ide_device->eject_button_poll(true);
     blink_poll();
 
+
     g_StatusController.ProcessUpdates();
+    
+    // Checks after 3 seconds if we are still on the Splash screen ( for example if there is no SD card)
+    if (!splash_over && (uint32_t)(millis() - splash_check_time) > 3000)
+    {
+      if (g_DisplayController.GetMode() == zuluide::control::Mode::Splash);
+      {
+        // Need to force a status controller update to move beyond the Splash screen
+        g_StatusController.SetFirmwareVersion(std::string(g_log_firmwareversion));
+      }
+      splash_over = true;
+    }
 
     save_logfile();
 

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,8 +27,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.04.18"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2025.04.22"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths


### PR DESCRIPTION
This is to address the issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/177

The issue is that if there is no SD card the splash screen on the controller board doesn't disappear until a SD card is loaded.

The fix is to force a status update, in this case setting the firmware version, after 3 seconds if the splash screen is still active.