### PR TITLE
Adjustable number of tick before a rotary action

### DIFF
--- a/lib/ZuluControl/include/zuluide/control/input_interface.h
+++ b/lib/ZuluControl/include/zuluide/control/input_interface.h
@@ -57,7 +57,7 @@ namespace zuluide::control {
     /***
         Provides the hardware interface with the receiver that should be notified when events are occuring.
      */
-    virtual void SetReciever(InputReceiver* reciever) = 0;
+    virtual void SetReceiver(InputReceiver* reciever) = 0;
 
     /***
         Tells the hardware interface to start sending events to the receiver.

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -327,7 +327,9 @@ void platform_set_display_controller(zuluide::Observable<zuluide::control::Displ
 
 void platform_set_input_interface(zuluide::control::InputReceiver* inputReceiver) {
   logmsg("Initialized platform controller with input receiver.");
-  g_rotary_input.SetReciever(inputReceiver);
+  uint8_t ticks = ini_getl("UI", "ticks", 1, CONFIGFILE);
+  g_rotary_input.SetSensitivity(ticks);
+  g_rotary_input.SetReceiver(inputReceiver);
   g_rotary_input.StartSendingEvents();
 }
 

--- a/lib/ZuluIDE_platform_RP2040/rotary_control.h
+++ b/lib/ZuluIDE_platform_RP2040/rotary_control.h
@@ -30,11 +30,36 @@
 #endif
 
 namespace zuluide::control {
+
+  enum rotary_direction_t {
+    ROTARY_DIR_NONE = 0,
+    ROTARY_DIR_CW   = 0x10,
+    ROTARY_DIR_CCW  = 0x20
+  };
+
+  // first two bits hold state of input
+  // 3rd bit holds rotation direction
+  enum rotatry_state_t {
+    ROTARY_TICK_000 = 0,
+    ROTARY_LAST_CW_001,
+    ROTARY_START_CW_010,
+    ROTARY_CONT_CW_011,
+    ROTARY_START_CCW_100,
+    ROTARY_LAST_CCW_101,
+    ROTARY_CONT_CCW_110,
+  };
+
   class RotaryControl : public InputInterface {
   public:
+
     RotaryControl(int addr = PCA9554_ADDR);
+
+    /*
+      \param ticks how many ticks before registering a change
+     */
+    void SetSensitivity(uint8_t ticks);
     void SetI2c(TwoWire* i2c);
-    virtual void SetReciever(InputReceiver* reciever);
+    virtual void SetReceiver(InputReceiver* receiver);
     virtual void StartSendingEvents();
     virtual void StopSendingEvents();
     virtual bool CheckForDevice() override;
@@ -50,14 +75,17 @@ namespace zuluide::control {
     TwoWire *wire;
     bool buttonIsPressed(bool isDown, uint32_t* lastDownMillis, uint32_t checkTime);
 
-    bool clockHigh;
-    int tickCount;
-    bool goingRight;
+    int tick_count;
+    bool going_cw;
 
+    uint8_t number_of_ticks;
     uint32_t eject_btn_millis;
     uint32_t insert_btn_millis;
     uint32_t rotate_btn_millis;
     uint8_t lrmem;
     int32_t lrsum;
+    uint8_t rotary_state;
+
+    static const uint8_t rotary_transition_lut[7][4];
   };
 }

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,8 +27,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.04.18"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2025.05.05"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -41,11 +41,11 @@
 
 # access_delay = 0   # Add extra delay (milliseconds) before answering to commands
 
-#max_volume = 100 # Audio max volume 0 - 100 (default)
+# max_volume = 100 # Audio max volume 0 - 100 (default)
 
 [UI]
 # An additional Pico W is required to utilize this experimental functionality, which is not yet generally available.
-#wifipassword="MY_PASSWORD" # Password for the WIFI network.
+# wifipassword="MY_PASSWORD" # Password for the WIFI network.
 # Any non-alphanumeric characters in the password must be in double quotes, as per the example above
-#wifissid="MY_NETWORK_SSID" # SSID for the WIFI network
-
+# wifissid="MY_NETWORK_SSID" # SSID for the WIFI network
+# ticks = 1 # number of ticks before the controller board registers turning of the rotary dial


### PR DESCRIPTION
The number to ticks of the rotary encoder before the ZuluIDE sends a clockwise or counter clockwise action is adjustable. It can be set in the `zuluide.ini` file under [UI] as `ticks = x` where x is the number of ticks. The default is now 1.

Switched to a state machine to decode the rotary encoder. This has two benefits over the previous version.
 1. It effectively debounces the inputs by ignoring their state changes
 2. It uses both rising and lower edges of channel A instead of just one