### PR TITLE
Rename ticks setting to rotary_encoder_ticks

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -940,10 +940,10 @@ void platform_poll()
     }
 
     // update settings for the controller board the first time SD is read
-    if (g_sdcard_present && !updated_controller_board)
+    if (!updated_controller_board && g_sdcard_present && g_rotary_input.GetDeviceExists())
     {
-        uint8_t ticks = ini_getl("UI", "ticks", 1, CONFIGFILE);
-        g_rotary_input.SetSensitivity(ticks);
+        uint8_t ticks = ini_getl("UI", "rotary_encoder_ticks", 1, CONFIGFILE);
+        g_rotary_input.SetTicks(ticks);
         updated_controller_board = true;
     }
 

--- a/lib/ZuluIDE_platform_RP2040/rotary_control.cpp
+++ b/lib/ZuluIDE_platform_RP2040/rotary_control.cpp
@@ -20,6 +20,7 @@
 **/
 
 #include "rotary_control.h"
+#include <ZuluIDE_log.h>
 
 using namespace zuluide::control;
 
@@ -77,8 +78,9 @@ uint8_t RotaryControl::getValue() {
   return input_byte;
 }
 
-void RotaryControl::SetSensitivity(uint8_t transitions) {
-  number_of_ticks = transitions;
+void RotaryControl::SetTicks(uint8_t ticks) {
+  number_of_ticks = ticks;
+  logmsg("Rotary encoder set to ", (int) number_of_ticks, " ticks before registering a rotation");
 }
 
 void RotaryControl::SetI2c(TwoWire* i2c) {

--- a/lib/ZuluIDE_platform_RP2040/rotary_control.h
+++ b/lib/ZuluIDE_platform_RP2040/rotary_control.h
@@ -57,7 +57,7 @@ namespace zuluide::control {
     /*
       \param ticks how many ticks before registering a change
      */
-    void SetSensitivity(uint8_t ticks);
+    void SetTicks(uint8_t ticks);
     void SetI2c(TwoWire* i2c);
     virtual void SetReceiver(InputReceiver* receiver);
     virtual void StartSendingEvents();

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -48,4 +48,4 @@
 # wifipassword="MY_PASSWORD" # Password for the WIFI network.
 # Any non-alphanumeric characters in the password must be in double quotes, as per the example above
 # wifissid="MY_NETWORK_SSID" # SSID for the WIFI network
-# ticks = 1 # number of ticks before the controller board registers turning of the rotary dial
+# rotary_encoder_ticks = 1 # number of ticks/detents before the controller board registers turning of the rotary dial


### PR DESCRIPTION
Renamed the `zuluide.ini` setting to be more specific. Added a log message informing the user of the setting only if the ZuluIDE detects the rotary controller.