### PR TITLE
Fix max_volume setting

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -285,7 +285,6 @@ void platform_late_init()
 #ifdef ENABLE_AUDIO_OUTPUT
     // one-time control setup for DMA channels and second core
     audio_init();
-    audio_set_max_volume((uint8_t) ini_getl("IDE", "max_volume", 100, CONFIGFILE));
 #endif
     platform_check_for_controller();
     __USBStart();
@@ -953,6 +952,19 @@ void platform_poll()
     usb_command_poll();
 
 #ifdef ENABLE_AUDIO_OUTPUT
+    static bool update_volume = false;
+    if (!update_volume && g_sdcard_present)
+    {
+        uint8_t max_volume = (uint8_t) ini_getl("IDE", "max_volume", 100, CONFIGFILE);
+        if (max_volume > 100)
+        {
+            max_volume = 100;
+            logmsg("The setting max_volume was set higher than 100, setting to 100 from ", (int) max_volume);
+        }
+        audio_set_max_volume(max_volume);
+        update_volume = true;
+        logmsg("Max volume set to ", (int) max_volume, "/100");
+    }
     audio_poll();
 #endif // ENABLE_AUDIO_OUTPUT
 }


### PR DESCRIPTION
The ini file was read for max_volume before the SD card was initialized. Moved the setting to the platform poll function so it is set when the SD card is inserted. It only reads the setting once. The max volume is be printed in the log when set.