### PR TITLE
Fix mixed mode CD audio track in Win 3.1

### DIFF
--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -1945,6 +1945,7 @@ size_t IDECDROMDevice::atapi_get_mode_page(uint8_t page_ctrl, uint8_t page_idx, 
 #endif
         write_be16(&buffer[12], 64); // read buffer (64KB)
         write_be16(&buffer[14],6292);  // current max read speed, state (40, ~6292KB/s)
+        return 16;
     }
     return IDEATAPIDevice::atapi_get_mode_page(page_ctrl, page_idx, buffer, max_bytes);
 }


### PR DESCRIPTION
This is for issue https://github.com/ZuluIDE/ZuluIDE-firmware/issues/214 A bug was found where an ATAPI mode sense 10 command interrupter's mode page function was returning a mode page buffer's length of 0 instead of 16 for page 0x2A. This fix returns the proper length of mode page buffer to command interrupter.