### PR TITLE
Fix slow transfer rate of multi bin file cd images

### DIFF
--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -1575,10 +1575,14 @@ bool IDECDROMDevice::getFirstLastTrackInfo(CUETrackInfo &first, CUETrackInfo &la
 uint64_t IDECDROMDevice::capacity_lba()
 {
     if (!m_image) return 0;
+    if (m_cached_capacity_lba == 0)
+    {
+        CUETrackInfo first, last;
+        getFirstLastTrackInfo(first, last);
+        m_cached_capacity_lba = (uint64_t)getLeadOutLBA(&last);
+    }
 
-    CUETrackInfo first, last;
-    getFirstLastTrackInfo(first, last);
-    return (uint64_t)getLeadOutLBA(&last);
+    return m_cached_capacity_lba;
 }
 
 
@@ -1798,6 +1802,7 @@ CUETrackInfo IDECDROMDevice::getTrackFromLBA(uint32_t lba)
 void IDECDROMDevice::clear_cached_track_info()
 {
     m_cached_end_lba = 0;
+    m_cached_capacity_lba = 0;
     memset(&m_cached_track_result, 0, sizeof(m_cached_track_result));
 }
 

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -123,8 +123,7 @@ protected:
     void clear_cached_track_info();
     CUETrackInfo m_cached_track_result;
     uint32_t m_cached_end_lba;
-
-
+    uint64_t m_cached_capacity_lba;
 
     // If the .cue file has data split across multiple files,
     // this function will reopen m_imagefile when track is changed.


### PR DESCRIPTION
Track information was being properly cached to speed up the transfer rate of the cue/multi-bin files CD images, but a call to capacity_lba caused the cache to be invalidated so the on every read the whole cue file was being processed each time.

The solution is to cache the return value of capacity_lba and invalidate the capacity value when the cached track information is invalidated. Now the transfer rate is the same as the other CD image formats.