### PR TITLE
Fix a 4GB offset limit in CD images

### DIFF
--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,8 +27,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.06.19"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2025.06.30"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths

--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -1203,7 +1203,7 @@ bool IDECDROMDevice::doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type
         uint64_t offset = trackinfo.file_offset;
         if (lba >= trackinfo.data_start)
         {
-            offset += (lba - trackinfo.data_start) * trackinfo.sector_length;
+            offset += (uint64_t)(lba - trackinfo.data_start) * trackinfo.sector_length;
         }
         else if (lba >= trackinfo.data_start - trackinfo.unstored_pregap_length)
         {


### PR DESCRIPTION
For this issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/217 There was a 32bit by 32bit multiplication that resulted in a truncated 32bit value when it was supposed to be 64bit offset into the image file of a CD-ROM disc. Casting an operand to 64bit fixes the issue.