### PR TITLE
ATAPI: Use maximum transfer size when host doesn't specify

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -227,7 +227,7 @@ bool IDEATAPIDevice::cmd_identify_packet_device(ide_registers_t *regs)
     idf[IDE_IDENTIFY_OFFSET_COMMAND_SET_SUPPORT_2] = 0x4000;
     idf[IDE_IDENTIFY_OFFSET_COMMAND_SET_SUPPORT_3] = 0x4000;
     idf[IDE_IDENTIFY_OFFSET_COMMAND_SET_ENABLED_1] = 0x0014;
-    idf[IDE_IDENTIFY_OFFSET_BYTE_COUNT_ZERO] = 128; // Number of bytes transferred when bytes_req = 0
+    idf[IDE_IDENTIFY_OFFSET_BYTE_COUNT_ZERO] = m_phy_caps.max_blocksize; // Number of bytes transferred when bytes_req = 0
 
     // Diagnostics results
     if (m_devconfig.dev_index == 0)
@@ -312,7 +312,7 @@ bool IDEATAPIDevice::cmd_packet(ide_registers_t *regs)
     {
         // "the host should not set the byte count limit to zero. If the host sets the byte count limit to
         // zero, the contents of IDENTIFY PACKET DEVICE word 125 determines the expected behavior"
-        m_atapi_state.bytes_req = 128;
+        m_atapi_state.bytes_req = m_phy_caps.max_blocksize;
     }
 
 #ifdef IDE_PHY_NO_DIRECT_ATAPI_SUPPORT


### PR DESCRIPTION
Previously when host requested transfer size of 0 (undefined), ZuluIDE would use arbitrary size of 128 bytes. This is valid but didn't work with Haiku operating system drivers.

After this commit requested size of 0 will use the maximum block size supported by ZuluIDE hardware (currently 4 kB).

Related issue: #219