### PR TITLE
Update libraries and USB product ID

### DIFF
--- a/boards/zuluide_rp2040.json
+++ b/boards/zuluide_rp2040.json
@@ -4,7 +4,7 @@
       "earlephilhower": {
         "boot2_source": "boot2_w25q080_2_padded_checksum.S",
         "usb_vid": "0x2E8A",
-        "usb_pid": "0xF00A"
+        "usb_pid": "0x10D7"
       }
     },
     "core": "earlephilhower",
@@ -18,7 +18,7 @@
       ],
       [
         "0x2E8A",
-        "0xF00A"
+        "0x10D7"
       ]
     ],
     "mcu": "rp2040",

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,17 +2,17 @@
 default_envs = ZuluIDE_RP2040
 
 [env:ZuluIDE_RP2040]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#19e30129fb1428b823be585c787dcb4ac0d9014c
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#6164ed92d83c1241a1d84ad848158d7b0fb486e3
 board_build.core = earlephilhower
 platform_packages =
-    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.3.0-DaynaPORT
+    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.7.0-DaynaPORT
 framework = arduino
 board = zuluide_rp2040
 extra_scripts = src/build_bootloader.py
 board_build.ldscript = lib/ZuluIDE_platform_RP2040/rp2040.ld
 ldscript_bootloader = lib/ZuluIDE_platform_RP2040/rp2040_btldr.ld
 lib_deps =
-    SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.3-gpt
+    SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.3-gpt-exfat
     minIni
     ZuluControl
     ZuluI2S

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,8 +27,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.07.17"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2025.08.08"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths


### PR DESCRIPTION
Updating to latest SDFat, PlatformIO platform, and package:
 - SDFat to exfat backported allocation fix
 - Latest RaspberryPi PlatformIO platform from Maximilian Gerhardt
 - Arduino-Pico v4.7.0 PlatformIO package from Earl F. Philhower
 - Pico SDK v2.2.0 from Raspberry Pi

Updated USB product ID to one assigned by Raspberry Pi to Rabbit Hole Computing