### PR TITLE
Ignore hidden directories and files

### DIFF
--- a/lib/ZuluControl/src/images/image_iterator.cpp
+++ b/lib/ZuluControl/src/images/image_iterator.cpp
@@ -315,10 +315,23 @@ static bool folderContainsCueSheet(FsFile &dir)
 }
 
 static bool fileIsValidImage(FsFile& file, const char* fileName, bool warning) {
-  // Directories are allowed if they contain a .cue sheet
-  if (file.isDirectory() && !folderContainsCueSheet(file)) {
-    if (warning) logmsg("-- Ignoring directory \"",fileName,"\", no .cue file found within");
+  if (file.isHidden())
     return false;
+
+  // Directories are allowed if they contain a .cue sheet and the first character is alphanumeric
+  if (file.isDirectory())
+  {
+    if (!isalnum(fileName[0]))
+    {
+      if (warning) logmsg("-- Ignoring directory \"",fileName,"\", first character is not alphanumeric");
+      return false;
+    }
+    if (!folderContainsCueSheet(file))
+    {
+      if (warning) logmsg("-- Ignoring directory \"",fileName,"\", no .cue file found within");
+      return false;
+    }
+    return true;
   }
 
   // If the file name is bad, skip it.


### PR DESCRIPTION
The image_iterator was looking at hidden files and folders. Now it silently ignores them.

Directories were being validated with the same filename criteria as files. Now directories are no longer filtered with the filename criteria.

Directories with the first character non-alphanumeric were being checked for cue files. Now only directories with the first character that is alphanumeric are being checked for cue files and there is a warning for the first character being non-alphanumeric.