### PR TITLE
Support for Western Digital Quick tester

### DIFF
--- a/lib/ZuluIDE_platform_RP2350/rp2350_ide_phy.cpp
+++ b/lib/ZuluIDE_platform_RP2350/rp2350_ide_phy.cpp
@@ -369,7 +369,7 @@ bool ide_phy_can_read_block()
 
 void ide_phy_start_read_buffer(uint32_t blocklen)
 {
-    assert(false); // TODO: implement
+    ide_phy_start_read(blocklen);
 }
 
 void ide_phy_read_block(uint8_t *buf, uint32_t blocklen, bool continue_transfer)

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -134,6 +134,7 @@ protected:
     virtual bool cmd_init_dev_params(ide_registers_t *regs);
     virtual bool cmd_identify_device(ide_registers_t *regs);
     virtual bool cmd_recalibrate(ide_registers_t *regs);
+    virtual bool cmd_standby_immediate(ide_registers_t *regs);
     virtual bool cmd_idle(ide_registers_t *regs);
 
     // Helper methods


### PR DESCRIPTION
This implements and fixes the commands to support a Western Digital Quick Tester when the ZuluIDE is in rigid mode (hard drive) for the V2 board.