### PR TITLE
RP2350: Update SDIO_RP2350 library to improve SD card compatibility

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -65,7 +65,7 @@ lib_deps =
     ZuluControl
     ZuluIDE_Audio_RP2MCU
     ZuluIDE_platform_RP2350
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.3
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
     CUEParser=https://github.com/rabbitholecomputing/CUEParser
     adafruit/Adafruit GFX Library
     adafruit/Adafruit BusIO


### PR DESCRIPTION
With this change, high speed SD communication is no longer attempted for cards that report class below 10. This improves compatibility with old SD cards.