### PR TITLE
Add support for the CMD-PCI640 IDE controller

### DIFF
--- a/boards/zuluide_rp2350.json
+++ b/boards/zuluide_rp2350.json
@@ -10,7 +10,7 @@
     "core": "earlephilhower",
     "cpu": "cortex-m33",
     "extra_flags": "-DARDUINO_GENERIC_RP2350 -DARDUINO_ARCH_RP2350 -DUSBD_MAX_POWER_MA=500 ",
-    "f_cpu": "200000000L",
+    "f_cpu": "150000000L",
     "hwids": [
       [
         "0x2E8A",

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -177,6 +177,7 @@ bool IDERigidDevice::handle_command(ide_registers_t *regs)
         // Supported IDE commands
         case IDE_CMD_NOP: return cmd_nop(regs);
         case IDE_CMD_SET_FEATURES: return cmd_set_features(regs);
+        case IDE_CMD_SEEK: return cmd_seek(regs);
         case IDE_CMD_READ_DMA: return cmd_read(regs, true, false);
         case IDE_CMD_WRITE_DMA: return cmd_write(regs, true);
         case IDE_CMD_READ_SECTORS_WOUT_RETRIES:
@@ -278,6 +279,14 @@ bool IDERigidDevice::cmd_set_features(ide_registers_t *regs)
 
     return true;
 }
+
+bool IDERigidDevice::cmd_seek(ide_registers_t *regs)
+{
+    // always return expected value
+    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
+    return true;
+}
+
 
 // "ATAPI devices shall swap bytes for ASCII fields to maintain compatibility with ATA."
 static void copy_id_string(uint16_t *dst, size_t maxwords, const char *src)

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -127,6 +127,7 @@ protected:
     // IDE command handlers
     virtual bool cmd_nop(ide_registers_t *regs);
     virtual bool cmd_set_features(ide_registers_t *regs);
+    virtual bool cmd_seek(ide_registers_t *regs);
     virtual bool cmd_read(ide_registers_t *regs, bool dma_transfer, bool verify_only);
     virtual bool cmd_write(ide_registers_t *regs, bool dma_transfer);
     virtual bool cmd_read_buffer(ide_registers_t *regs);


### PR DESCRIPTION
Tested as a bootable hard drive on a Digital Celebris with a CMD PCI-640 IDE controller, using a version of Window 98 on the ZuluIDE V2.