### PR TITLE
Remove Get Performance not support log message

### DIFF
--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -432,6 +432,9 @@ bool IDECDROMDevice::handle_atapi_command(const uint8_t *cmd)
         case ATAPI_CMD_PAUSE_RESUME_AUDIO:      return atapi_pause_resume_audio(cmd);
         case ATAPI_CMD_STOP_PLAY_SCAN_AUDIO:    return atapi_stop_play_scan_audio(cmd);
         case ATAPI_CMD_SEEK10:                  return atapi_seek_10(cmd);
+        // Stream feature not supported, returning invalid command here
+        // to avoid warnings in log
+        case ATAPI_CMD_GET_PERFORMANCE:         return atapi_cmd_error(ATAPI_SENSE_ILLEGAL_REQ, ATAPI_ASC_INVALID_CMD);
 
         default:
             return IDEATAPIDevice::handle_atapi_command(cmd);


### PR DESCRIPTION
Removing
`-- WARNING: Unsupported ATAPI command ATAPI_CMD_GET_PERFORMANCE` 
The command is only needed for devices with the Streaming Feature, currently unsupported.
Some ATAPI hosts send the command before querying if the feature is enabled.