### PR TITLE
Fix stack overflow with multiple image files

### DIFF
--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -157,4 +157,7 @@ protected:
     bool doPauseResumeAudio(bool resume);
 
     bool doPlayAudio(uint32_t lba, uint32_t length);
+
+    // shared memory for when a temporary filename is need
+    char m_filename[MAX_FILE_PATH + 1];
 };

--- a/utils/analyze_crashlog.sh
+++ b/utils/analyze_crashlog.sh
@@ -24,7 +24,7 @@ fwtime=$(grep 'FW Version' $logfile | tail -n 1 | egrep -o '[A-Z][a-z][a-z]\s+[0
 # Check if the firmware file is available locally
 echo "Searching for firmware compiled at $fwtime"
 scriptdir=$( dirname -- "${BASH_SOURCE[0]}" )
-fwfile=$(find $scriptdir/.. $2 -name '*.elf' -exec grep -q "$fwtime" {} \; -print -quit)
+fwfile=$(find $scriptdir/.. $2 -name '*.elf' ! -name 'bootloader.elf' -exec grep -q "$fwtime" {} \; -print -quit)
 
 # Search Github for artifacts uploaded within few minutes of the compilation time
 if [ "x$fwfile" = "x" ]; then


### PR DESCRIPTION
The firmware was crashing with a stack overflow when multiple images had to be iterated through.

Merged temporary filename strings into a single temporary string off the stack in `ide_cdrom.cpp` and made temporary filenames in the image iterator static so they to would not be place on the stack.

Tested with over 300 iso images and was crash free.

Also excluded "bootloader.elf" from the `analyze_crashlog.sh` script as it would usually be found before firmware.elf and not display the proper stack trace.