### PR TITLE
Stub out ATA command Idle and Standby

### DIFF
--- a/src/ide_constants.h
+++ b/src/ide_constants.h
@@ -89,6 +89,9 @@ X(IDE_CMD_CFA_TRANSLATE_SECTOR                      , 0x87) \
 X(IDE_CMD_EXECUTE_DEVICE_DIAGNOSTIC                 , 0x90) \
 X(IDE_CMD_INIT_DEV_PARAMS                           , 0x91) \
 X(IDE_CMD_DOWNLOAD_MICROCODE                        , 0x92) \
+X(IDE_CMD_STANDBY_IMMEDIATE_94H                     , 0x94) \
+X(IDE_CMD_IDLE_IMMEDIATE_95H                        , 0x95) \
+X(IDE_CMD_STANDBY_96H                               , 0x96) \
 X(IDE_CMD_IDLE_97H                                  , 0x97) \
 X(IDE_CMD_PACKET                                    , 0xA0) \
 X(IDE_CMD_IDENTIFY_PACKET_DEVICE                    , 0xA1) \
@@ -108,9 +111,9 @@ X(IDE_CMD_CHECK_MEDIA_CARD_TYPE                     , 0xD1) \
 X(IDE_CMD_GET_MEDIA_STATUS                          , 0xDA) \
 X(IDE_CMD_MEDIA_LOCK                                , 0xDE) \
 X(IDE_CMD_MEDIA_UNLOCK                              , 0xDF) \
-X(IDE_CMD_STANDBY_IMMEDIATE                         , 0xE0) \
-X(IDE_CMD_IDLE_IMMEDIATE                            , 0xE1) \
-X(IDE_CMD_STANDBY                                   , 0xE2) \
+X(IDE_CMD_STANDBY_IMMEDIATE_E0H                     , 0xE0) \
+X(IDE_CMD_IDLE_IMMEDIATE_E1H                        , 0xE1) \
+X(IDE_CMD_STANDBY_E2H                               , 0xE2) \
 X(IDE_CMD_IDLE_E3H                                  , 0xE3) \
 X(IDE_CMD_READ_BUFFER                               , 0xE4) \
 X(IDE_CMD_CHECK_POWER_MODE                          , 0xE5) \

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -189,11 +189,14 @@ bool IDERigidDevice::handle_command(ide_registers_t *regs)
         case IDE_CMD_INIT_DEV_PARAMS: return cmd_init_dev_params(regs);
         case IDE_CMD_IDENTIFY_DEVICE: return cmd_identify_device(regs);
         case IDE_CMD_RECALIBRATE: return cmd_recalibrate(regs);
-        case IDE_CMD_STANDBY_IMMEDIATE: return cmd_standby_immediate(regs);
-        case IDE_CMD_IDLE_97H:
+        case IDE_CMD_STANDBY_IMMEDIATE_94H: // fall through
+        case IDE_CMD_STANDBY_IMMEDIATE_E0H: // fall through
+        case IDE_CMD_STANDBY_96H:           // fall through
+        case IDE_CMD_STANDBY_E2H: return cmd_standby(regs);
+        case IDE_CMD_IDLE_IMMEDIATE_95H: // fall through
+        case IDE_CMD_IDLE_IMMEDIATE_E1H: // fall through
+        case IDE_CMD_IDLE_97H:           // fall through
         case IDE_CMD_IDLE_E3H: return cmd_idle(regs);
-
-
         default: return false;
     }
 }
@@ -657,19 +660,30 @@ bool IDERigidDevice::cmd_recalibrate(ide_registers_t *regs)
     return true;
 }
 
-bool IDERigidDevice::cmd_standby_immediate(ide_registers_t *regs)
+bool IDERigidDevice::cmd_standby(ide_registers_t *regs)
 {
+    if (regs->command == IDE_CMD_STANDBY_96H || regs->command == IDE_CMD_STANDBY_E2H)
+    {
+        dbgmsg("Standby command is a stub, timeout value of ", regs->sector_count, " ignored. Signaling INTRQ and device ready");
+    }
+    else
+    {
+        dbgmsg("Standby immediate command is a stub, signaling INTRQ and device ready");
+    }
     ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
     return true;
 }
 
 bool IDERigidDevice::cmd_idle(ide_registers_t *regs)
 {
-    if (regs->sector_count == 0)
-        dbgmsg("IDERigidDevice::cmd_idle() - disabling timeout");
+    if (regs->command == IDE_CMD_IDLE_97H || regs->command == IDE_CMD_IDLE_E3H)
+    {
+        dbgmsg("Idle command is a stub, timeout value of ", regs->sector_count, " ignored. Signaling INTRQ and device ready");
+    }
     else
-        dbgmsg("IDERigidDevice::cmd_idle() - ignoring timeout setting ");
-
+    {
+        dbgmsg("Idle immediate command is a stub, signaling INTRQ and device ready");
+    }
     ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
     return true;
 }

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -135,7 +135,7 @@ protected:
     virtual bool cmd_init_dev_params(ide_registers_t *regs);
     virtual bool cmd_identify_device(ide_registers_t *regs);
     virtual bool cmd_recalibrate(ide_registers_t *regs);
-    virtual bool cmd_standby_immediate(ide_registers_t *regs);
+    virtual bool cmd_standby(ide_registers_t *regs);
     virtual bool cmd_idle(ide_registers_t *regs);
 
     // Helper methods


### PR DESCRIPTION
This stubs out Idle, Idle Immediate, Standby and Standby Immediate for both their 0x9X and 0xEX command versions.
This is for issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/234