### PR TITLE
Upgrade to custom spin of arduino-pico v5.4.2 library

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -42,7 +42,7 @@
 #include <pico/multicore.h>
 #include "rp2040_fpga.h"
 #include <strings.h>
-#include <RP2040USB.h>
+#include <USB.h>
 #include <SerialUSB.h>
 #include <class/cdc/cdc_device.h>
 #include <Wire.h>
@@ -299,7 +299,7 @@ void platform_late_init()
     audio_init();
 #endif
     platform_check_for_controller();
-    __USBStart();
+    USB.begin();
 }
 
 uint8_t platform_check_for_controller()

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ build_flags =
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#6164ed92d83c1241a1d84ad848158d7b0fb486e3
 board_build.core = earlephilhower
 platform_packages =
-    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.7.0-DaynaPORT
+    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v5.4.2-DaynaPORT
 framework = arduino
 board = zuluide_rp2040
 extra_scripts = src/build_bootloader.py


### PR DESCRIPTION
Upgraded to a custom spin of arduino-pico v5.4.2 and fix breaking USB library change.