### PR TITLE
Add initial support for large CUE files

### DIFF
--- a/lib/SharedCUEParser/SharedCUEParser.cpp
+++ b/lib/SharedCUEParser/SharedCUEParser.cpp
@@ -1,0 +1,97 @@
+    
+#include "scp/SharedCUEParser.h"
+#include <string.h>
+#include <SdFat.h>
+
+extern SdFs SD;
+char SharedCUEParser::_current_file_loaded[CUE_MAX_FILENAME + 1] = {0};
+char SharedCUEParser::_shared_cuesheet[MAX_SHARED_CUE_SHEET_SIZE];
+
+static void write_default_cuesheet(char * cue_sheet)
+{
+    strcpy(cue_sheet, R"(
+    FILE "" BINARY
+    TRACK 01 MODE1/2048
+    INDEX 01 00:00:00
+    )");
+}
+
+SharedCUEParser::SharedCUEParser()
+{
+    _cue_filepath[0] = '\0';
+    m_cue_sheet = _shared_cuesheet;
+    if (_shared_cuesheet[0] == '\0')
+    {
+        write_default_cuesheet(_shared_cuesheet);
+    }
+    restart();
+}
+
+SharedCUEParser::SharedCUEParser(char* path)
+{
+    strcpy(_cue_filepath, path);
+    m_cue_sheet = _shared_cuesheet;
+    if (path[0] == '\0' && _shared_cuesheet[0] == '\0')
+    {
+        write_default_cuesheet(_shared_cuesheet);
+    }
+    restart();
+}
+
+// Restart parsing from beginning of file
+void SharedCUEParser::restart()
+{
+    update_file();
+    CUEParser::restart();
+}
+const CUETrackInfo *SharedCUEParser::next_track()
+{ 
+    update_file();
+    return CUEParser::next_track();
+}
+
+
+const CUETrackInfo *SharedCUEParser::next_track(uint64_t prev_file_size)
+{
+    update_file();
+    return CUEParser::next_track(prev_file_size);
+}
+
+void SharedCUEParser::update_file()
+{
+    if ( strcasecmp(_cue_filepath, _current_file_loaded) != 0)
+    {
+        strcpy(_current_file_loaded, _cue_filepath);
+        // Empty filepath, load simple cuesheet
+        if (_current_file_loaded[0] == '\0')
+        {
+            write_default_cuesheet(_shared_cuesheet);
+        }
+        else
+        {
+
+            FsFile file = SD.open(_current_file_loaded);
+            if (file.isOpen())
+            {
+                int count = file.read(_shared_cuesheet, sizeof(_shared_cuesheet));
+                file.close();
+                // on read error, set _shared_cuesheet to an empty string;
+                if (count <= 0)
+                {
+                    _shared_cuesheet[0] = '\0';
+                }
+                else
+                {
+                    // Null terminate data into a valid string
+                    _shared_cuesheet[count] = '\0';
+                }
+            }
+            else
+            {
+                // on open error, set _shared_cuesheet to an empty string;
+                _shared_cuesheet[0] = '\0';
+            }
+        }
+    }
+}
+

--- a/lib/SharedCUEParser/scp/SharedCUEParser.h
+++ b/lib/SharedCUEParser/scp/SharedCUEParser.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <memory>
+#include <CUEParser.h>
+#ifndef MAX_SHARED_CUE_SHEET_SIZE 
+#  define MAX_SHARED_CUE_SHEET_SIZE (12 * 1024)
+#endif
+
+class SharedCUEParser : public CUEParser
+{
+public:
+    SharedCUEParser();
+    SharedCUEParser(char* path);
+    
+    // Restart parsing from beginning of file
+    virtual void restart() override;
+
+    // Get information for next track.
+    // Returns nullptr when there are no more tracks.
+    // The returned pointer remains valid until next call to next_track()
+    // or destruction of this object.
+    virtual const CUETrackInfo *next_track() override;
+
+    // Same as next_track(), but takes the file size into account when
+    // switching files. This is necessary for getting the correct track
+    // lengths when the .cue file references multiple .bin
+    virtual const CUETrackInfo *next_track(uint64_t prev_file_size) override;
+
+    inline static size_t max_cue_sheet_size(){ return MAX_SHARED_CUE_SHEET_SIZE;}
+protected:
+    // Checks to see if the current buffer is using the needed cue file
+    // If not, loads the correct _cue_file into the _shared_cuesheet buffer
+    virtual void update_file();
+    char static _shared_cuesheet[MAX_SHARED_CUE_SHEET_SIZE];
+    char static _current_file_loaded[CUE_MAX_FILENAME + 1];
+    char _cue_filepath[CUE_MAX_FILENAME + 1];
+
+};

--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -30,7 +30,6 @@
 #include <SdFat.h>
 #include <CUEParser.h>
 
-#define MAX_CUE_SHEET_SIZE 4096
 // Maximum path length for files on SD card
 #define MAX_FILE_PATH 255
 
@@ -85,7 +84,6 @@ namespace zuluide::images {
     bool currentIsFirst;
     bool currentIsLast;
     bool parseMultiPartBinCueSize;
-    static char cuesheet[MAX_CUE_SHEET_SIZE];
   };
   
 }

--- a/lib/ZuluControl/include/zuluide/pipe/image_response_pipe.h
+++ b/lib/ZuluControl/include/zuluide/pipe/image_response_pipe.h
@@ -160,7 +160,6 @@ void ImageResponsePipe<SrcType>::HandleRequest(ImageRequest<SrcType>& current)
         }
         else
         {
-          logmsg("Got matching file for current");
           response->SetStatus(imageIterator.IsLast() ? response_status_t::End : response_status_t::More);
           response->SetImage(std::move(std::make_unique<zuluide::images::Image>(imageIterator.Get())));
         }

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,12 +23,12 @@ lib_deps =
     ZuluControl
     ZuluIDE_Audio_RP2MCU
     ZuluIDE_platform_RP2040
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2025.02.25
-    adafruit/Adafruit GFX Library
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#virtualize
     adafruit/Adafruit BusIO
     adafruit/Adafruit SSD1306
     DisplaySSD1306
     IOExpanderPCA9554
+    SharedCUEParser
 debug_tool = cmsis-dap
 debug_build_flags =
     -O2 -ggdb -g3
@@ -66,12 +66,13 @@ lib_deps =
     ZuluIDE_Audio_RP2MCU
     ZuluIDE_platform_RP2350
     SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#virtualize
     adafruit/Adafruit GFX Library
     adafruit/Adafruit BusIO
     adafruit/Adafruit SSD1306
     DisplaySSD1306
     IOExpanderPCA9554
+    SharedCUEParser
 debug_tool = cmsis-dap
 debug_build_flags =
     -O2 -ggdb -g3

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -28,7 +28,7 @@
 #pragma once
 
 #include "ide_atapi.h"
-#include <CUEParser.h>
+#include <scp/SharedCUEParser.h>
 
 // Event Status Notification handling
 class IDECDROMDevice: public IDEATAPIDevice
@@ -118,8 +118,7 @@ protected:
     virtual ssize_t read_callback(const uint8_t *data, size_t blocksize, size_t num_blocks);
 
     // Access data from CUE sheet, or dummy data if no cue sheet provided
-    char m_cuesheet[4096];
-    CUEParser m_cueparser;
+    SharedCUEParser m_cueparser;
     bool loadAndValidateCueSheet(FsFile *dir, const char *cuesheetname);
     bool getFirstLastTrackInfo(CUETrackInfo &first, CUETrackInfo &last);
     uint32_t getLeadOutLBA(const CUETrackInfo* lasttrack);


### PR DESCRIPTION
An issue customers encountered was their CUE files were to large for the ZuluIDE to handle. This could not be easily fixed by increasing the CUE buffer sizes. Up to 4 x 4k buffers for cue files corresponding to different instances of the CUE parser could be allocated at one time.

The following solution uses one shared CUE buffer.

To do this a sub class around the CUEParser library called the SharedCUEParser is used. It uses a shared buffer between objects to store the CUE file. With each public method of CUEParser it first checks to see if the CUE file currently in the shared buffer is for the current object. If it isn't, it reads the correct CUE file into the buffer from the SD card.

This is initial support without much error checking.