### PR TITLE
Fix stack overflow with shared cue parser

### DIFF
--- a/lib/SharedCUEParser/SharedCUEParser.cpp
+++ b/lib/SharedCUEParser/SharedCUEParser.cpp
@@ -18,17 +18,16 @@ static void write_default_cuesheet(char * cue_sheet)
 
 SharedCUEParser::SharedCUEParser()
 {
-    _cue_filepath[0] = '\0';
-    m_cue_sheet = _shared_cuesheet;
-    if (_shared_cuesheet[0] == '\0')
-    {
-        write_default_cuesheet(_shared_cuesheet);
-    }
-    restart();
+    set("");
 }
 
-SharedCUEParser::SharedCUEParser(char* path)
+SharedCUEParser::SharedCUEParser(const char* path)
 {
+    set(path);
+}
+
+ void SharedCUEParser::set(const char* path)
+ {
     strcpy(_cue_filepath, path);
     m_cue_sheet = _shared_cuesheet;
     if (path[0] == '\0' && _shared_cuesheet[0] == '\0')
@@ -36,7 +35,7 @@ SharedCUEParser::SharedCUEParser(char* path)
         write_default_cuesheet(_shared_cuesheet);
     }
     restart();
-}
+ }
 
 // Restart parsing from beginning of file
 void SharedCUEParser::restart()

--- a/lib/SharedCUEParser/scp/SharedCUEParser.h
+++ b/lib/SharedCUEParser/scp/SharedCUEParser.h
@@ -9,8 +9,9 @@ class SharedCUEParser : public CUEParser
 {
 public:
     SharedCUEParser();
-    SharedCUEParser(char* path);
+    SharedCUEParser(const char* path);
     
+    virtual void set(const char* path);
     // Restart parsing from beginning of file
     virtual void restart() override;
 


### PR DESCRIPTION
After implementing a large shared buffer for CUE files a stack overflow error was detected on the V2. It may have also been happening on the RP2040 since it doesn't have stack overflow protection.

To fix the issue a set method for the SharedCUEParser was created. This is so loadAndValidateCueSheet function can avoid creating a new object and then copying the object to member SharedCUEParser object. Now the set method modifies the object directly without the need to allocated anything.

Also set a filename string to static in loadAndValidateCueSheet to save space on the stack.