### PR TITLE
This fixes issues with VIDECDD.sys and LG eject

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -889,7 +889,7 @@ bool IDEATAPIDevice::atapi_test_unit_ready(const uint8_t *cmd)
 
     if (m_atapi_state.not_ready)
     {
-        return atapi_cmd_not_ready_error();
+        return atapi_cmd_error(ATAPI_SENSE_NOT_READY, ATAPI_ASC_MEDIUM_CHANGE);
     }
     return atapi_cmd_ok();
 }
@@ -1191,7 +1191,7 @@ bool IDEATAPIDevice::atapi_read_capacity(const uint8_t *cmd)
 {
     if (!is_medium_present()) return atapi_cmd_not_ready_error();
 
-    if (m_atapi_state.not_ready) return atapi_cmd_error(ATAPI_SENSE_NOT_READY, ATAPI_ASC_UNIT_BECOMING_READY);
+    if (m_atapi_state.not_ready) return atapi_cmd_error(ATAPI_SENSE_NOT_READY, ATAPI_ASC_MEDIUM_CHANGE);
 
     uint32_t last_lba = this->capacity_lba() - 1;
     uint8_t *buf = m_buffer.bytes;
@@ -1228,7 +1228,7 @@ bool IDEATAPIDevice::atapi_read(const uint8_t *cmd)
     }
 
     if (!is_medium_present()) return atapi_cmd_not_ready_error();
-    if (m_atapi_state.not_ready) return atapi_cmd_error(ATAPI_SENSE_NOT_READY, ATAPI_ASC_UNIT_BECOMING_READY);
+    if (m_atapi_state.not_ready) return atapi_cmd_error(ATAPI_SENSE_NOT_READY, ATAPI_ASC_MEDIUM_CHANGE);
 
     if (lba + transfer_len > capacity_lba())
     {
@@ -1277,7 +1277,7 @@ bool IDEATAPIDevice::atapi_write(const uint8_t *cmd)
     {
         return atapi_cmd_not_ready_error();
     }
-    else if (m_atapi_state.not_ready) return atapi_cmd_error(ATAPI_SENSE_NOT_READY, ATAPI_ASC_UNIT_BECOMING_READY);
+    else if (m_atapi_state.not_ready) return atapi_cmd_error(ATAPI_SENSE_NOT_READY, ATAPI_ASC_MEDIUM_CHANGE);
 
     uint32_t lba, transfer_len;
     if (cmd[0] == ATAPI_CMD_WRITE6)


### PR DESCRIPTION
This fixes an issue with VIDECDD.sys mounting new media after and eject command. And an infinite loop the LG driver's universal eject DOS command got into.

VIDECDD.sys now works correctly with the zuluide.ini file setting `set_not_ready_on_insert=1`. It will change out the volume after and eject. This was done by returning ATAPI_ASC_MEDIUM_CHANGE (ASC 0x28) on the next command after the disc has been ejected.

The LG `EJECT` command no longer goes into an infinite loop. This was fixed by setting the mode sense page
`CD/DVD Capabilities and Mechanical Status Page (Page Code 2Ah)` Lock support on byte 6 to 1.