### PR TITLE
ZuluIDE V2: Fix stack overflow when zululast.txt isn't present

### DIFF
--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -66,11 +66,17 @@ namespace zuluide::images {
 	Defaults to true.
      **/
     void SetParseMultiPartBinCueSize(bool value);
+
   private:
     bool Move(bool forward = true);
     bool FetchSizeFromCueFile();
     FsFile currentFile;
-    FsFile root;
+    bool is_valid_filename(const char *name, bool warning = false);
+    bool fileIsValidImage(FsFile& file, const char* fileName, bool warning = false);
+    bool tryReadQueueSheet(FsFile &cuesheetfile);
+    bool searchForCueSheetFile(FsFile *directory, FsFile &outputFile);
+    bool folderContainsCueSheet(FsFile &dir);
+
     char candidate[MAX_FILE_PATH + 1];
     uint64_t candidateSizeInBytes;
     Image::ImageType candidateImageType;
@@ -84,6 +90,10 @@ namespace zuluide::images {
     bool currentIsFirst;
     bool currentIsLast;
     bool parseMultiPartBinCueSize;
+
+    static FsFile root;
+    static char tmpFilePath[MAX_FILE_PATH + 1];
+    static FsFile tmpFsFile;
   };
   
 }

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -573,7 +573,7 @@ void loadFirstImage() {
   bool quiet = ini_getbool("IDE", "quiet_image_parsing", 0, CONFIGFILE);
   if (!quiet) logmsg("Parsing images on the SD card");
   zuluide::images::ImageIterator imgIterator;
-  volatile bool success = false;
+  bool success = false;
   if (ini_getbool("IDE", "init_with_last_used_image", 1, CONFIGFILE))
   {
     imgIterator.Reset(!quiet);
@@ -596,11 +596,13 @@ void loadFirstImage() {
         if (!quiet) logmsg("-- Last used image \"", image_name.c_str(), "\" not found");
       }
     }
+    quiet = true;
   }
 
   if (!success)
   {
-    imgIterator.Reset(true);
+
+    imgIterator.Reset(!quiet);
     if (!imgIterator.IsEmpty() && imgIterator.MoveNext()) {
       logmsg("Loading first image ", imgIterator.Get().GetFilename().c_str());
       g_StatusController.LoadImage(imgIterator.Get());


### PR DESCRIPTION
For multi bin/cue files when zululast.txt file is not present a stack overflow occurs. This fix created a temp filepath static class array, a static temp FsFile handler along with making the FsFile handler for the root directory of the SD card static also. The temporary static variables are used in place of some of the local variables in member methods. This saved enough memory on the stack to fix the issue.

Printing out the rejected files and directories no longer does it twice when zululast.txt file is not present.