### PR TITLE
Fix unit attention / media change

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -655,12 +655,14 @@ void status_observer(const zuluide::status::SystemStatus& current) {
     load_image(current.GetLoadedImage());
     g_ide_device->set_loaded_without_media(false);
     loadedFirstImage = true;
+    g_ide_device->loaded_new_media();
   }
   else if ((loadedFirstImage && !current.LoadedImagesAreEqual(g_previous_controller_status))) {
     // The current image has changed.
     if (current.HasLoadedImage()) 
     {
       load_image(current.GetLoadedImage());
+      g_ide_device->loaded_new_media();
     } 
     else
     {

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -86,6 +86,8 @@ public:
 
     virtual inline bool is_removable() override {return m_devinfo.removable;}
 
+    virtual void loaded_new_media() override;
+
     virtual inline bool is_loaded_without_media() override {return m_removable.loaded_without_media;}
     virtual inline void set_loaded_without_media(bool no_media) override {m_removable.loaded_without_media = no_media;}
     virtual inline void set_load_first_image_cb(void (*load_image_cb)()) override {m_removable.load_first_image_cb = load_image_cb;}
@@ -197,6 +199,8 @@ protected:
     bool atapi_cmd_ok();
 
     // ATAPI command handlers
+
+    virtual bool handle_atapi_command_wrapper(const uint8_t *cmd);
     virtual bool handle_atapi_command(const uint8_t *cmd);
     virtual bool atapi_test_unit_ready(const uint8_t *cmd);
     virtual bool atapi_start_stop_unit(const uint8_t *cmd);

--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -459,7 +459,6 @@ bool IDECDROMDevice::atapi_read_disc_information(const uint8_t *cmd)
     doStopAudio();
 
     if (!is_medium_present()) return atapi_cmd_not_ready_error();
-    if (m_atapi_state.not_ready) return atapi_cmd_error(ATAPI_SENSE_NOT_READY, ATAPI_ASC_UNIT_BECOMING_READY);
 
     uint16_t allocationLength = parse_be16(&cmd[7]);
 
@@ -1630,6 +1629,7 @@ void IDECDROMDevice::button_eject_media()
     {
         m_removable.loaded_without_media = false;
         if(m_removable.load_first_image_cb) m_removable.load_first_image_cb();
+        loaded_new_media();
     }
     else if (m_removable.prevent_removable)
     {
@@ -1674,7 +1674,7 @@ void IDECDROMDevice::insert_media(IDEImage *image)
             m_removable.ejected = false;
             set_image(&g_ide_imagefile);
             set_esn_event(esn_event_t::MNewMedia);
-            set_not_ready(true);
+            loaded_new_media();
         }
     }
     img_iterator.Cleanup();
@@ -1717,6 +1717,7 @@ void IDECDROMDevice::insert_next_media(IDEImage *image)
                 g_previous_controller_status = g_StatusController.GetStatus();
                 g_StatusController.LoadImage(img_iterator.Get());
                 set_esn_event(esn_event_t::MNewMedia);
+                loaded_new_media();
             }
         }
         img_iterator.Cleanup();

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -96,6 +96,9 @@ public:
     // Is device removable
     virtual bool is_removable() = 0;
 
+    // Run when new media is loaded
+    virtual void loaded_new_media() = 0;
+
     // This is the state of media for the device at init or SD insertion
     virtual bool is_loaded_without_media() = 0;
     virtual void set_loaded_without_media(bool no_media) = 0;

--- a/src/ide_removable.cpp
+++ b/src/ide_removable.cpp
@@ -74,9 +74,6 @@ void IDERemovable::set_image(IDEImage *image)
 
     IDEATAPIDevice::set_image(image);
 
-    // Notify host of media change
-    m_atapi_state.unit_attention = true;
-
     if (!image)
     {
         m_devinfo.media_status_events = ATAPI_MEDIA_EVENT_EJECTREQ;

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -152,9 +152,6 @@ void IDERigidDevice::reset()
 void IDERigidDevice::set_image(IDEImage *image)
 {
     m_image = image;
-    // \todo replace with ATA media change
-    // m_atapi_state.unit_attention = true;
-    // m_atapi_state.sense_asc = ATAPI_ASC_MEDIUM_CHANGE;
 }
 
 void IDERigidDevice::insert_media(IDEImage *image)

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -81,7 +81,9 @@ public:
     virtual inline bool is_loaded_without_media() override {return false;}
     virtual inline void set_loaded_without_media(bool no_media) override{;}
 
-    virtual void set_load_first_image_cb(void (*load_image_cb)()) override {;}
+    virtual inline void loaded_new_media() override {;}
+
+    virtual inline void set_load_first_image_cb(void (*load_image_cb)()) override {;}
 protected:
     IDEImage *m_image;
 

--- a/src/ide_zipdrive.cpp
+++ b/src/ide_zipdrive.cpp
@@ -110,6 +110,7 @@ void IDEZipDrive::button_eject_media()
     {
         m_removable.loaded_without_media = false;
         if(m_removable.load_first_image_cb) m_removable.load_first_image_cb();
+        loaded_new_media();
     }
     else if (m_removable.prevent_removable)
         m_zip_disk_info.button_pressed = true;
@@ -140,9 +141,7 @@ void IDEZipDrive::insert_media(IDEImage *image)
             logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
             m_removable.ejected = false;
             set_image(&g_ide_imagefile);
-            m_atapi_state.unit_attention = true;
-            m_atapi_state.sense_asc = ATAPI_ASC_MEDIUM_CHANGE;
-            set_not_ready(true);
+            loaded_new_media();
         }
     }
         img_iterator.Cleanup();


### PR DESCRIPTION
Unit attention is supposed raised before any ATAPI command besides inquiry and request sense, which it does for the base class ATAPI command handling. CDROM ATAPI command handling checked for CDROM commands first before running the ATAPI command handler so unit attention was not being handled correctly.

Created a wrapper for the ATAPI command handler which always raises the unit attention sense key first, before running the derived method ATAPI command handler. Change the raising of the unit attention/media change sense key/asc to a method that runs when media has been changed. Inserted the method in the appropriate places. The method also uses the optional not ready setting. If set, it will always raise a not ready sense key before the raising media change sense key on the next ATAPI command.