### PR TITLE
Longer full path names and fewer cue sheet hits

### DIFF
--- a/lib/SharedCUEParser/SharedCUEParser.cpp
+++ b/lib/SharedCUEParser/SharedCUEParser.cpp
@@ -1,10 +1,34 @@
-    
+/**
+ * ZuluIDE™ - Copyright (c) 2025 Rabbit Hole Computing™
+ *
+ * ZuluIDE™ firmware is licensed under the GPL version 3 or any later version. 
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version. 
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ *
+ * Under Section 7 of GPL version 3, you are granted additional
+ * permissions described in the ZuluIDE Hardware Support Library Exception
+ * (GPL-3.0_HSL_Exception.md), as published by Rabbit Hole Computing™.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
 #include "scp/SharedCUEParser.h"
 #include <string.h>
 #include <SdFat.h>
 
 extern SdFs SD;
-char SharedCUEParser::_current_file_loaded[CUE_MAX_FILENAME + 1] = {0};
+char SharedCUEParser::_current_file_loaded[CUE_MAX_FULL_FILEPATH + 1] = {0};
 char SharedCUEParser::_shared_cuesheet[MAX_SHARED_CUE_SHEET_SIZE];
 
 static void write_default_cuesheet(char * cue_sheet)
@@ -28,7 +52,7 @@ SharedCUEParser::SharedCUEParser(const char* path)
 
  void SharedCUEParser::set(const char* path)
  {
-    strcpy(_cue_filepath, path);
+    strlcpy(_cue_filepath, path, sizeof(_cue_filepath));
     m_cue_sheet = _shared_cuesheet;
     if (path[0] == '\0' && _shared_cuesheet[0] == '\0')
     {
@@ -60,7 +84,7 @@ void SharedCUEParser::update_file()
 {
     if ( strcasecmp(_cue_filepath, _current_file_loaded) != 0)
     {
-        strcpy(_current_file_loaded, _cue_filepath);
+        strlcpy(_current_file_loaded, _cue_filepath, sizeof(_current_file_loaded));
         // Empty filepath, load simple cuesheet
         if (_current_file_loaded[0] == '\0')
         {

--- a/lib/SharedCUEParser/scp/SharedCUEParser.h
+++ b/lib/SharedCUEParser/scp/SharedCUEParser.h
@@ -1,9 +1,36 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2025 Rabbit Hole Computing™
+ *
+ * ZuluIDE™ firmware is licensed under the GPL version 3 or any later version. 
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version. 
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ *
+ * Under Section 7 of GPL version 3, you are granted additional
+ * permissions described in the ZuluIDE Hardware Support Library Exception
+ * (GPL-3.0_HSL_Exception.md), as published by Rabbit Hole Computing™.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
 #pragma once
 #include <memory>
 #include <CUEParser.h>
 #ifndef MAX_SHARED_CUE_SHEET_SIZE 
 #  define MAX_SHARED_CUE_SHEET_SIZE (12 * 1024)
 #endif
+// Something like "/path_from_root/filename"
+#define CUE_MAX_FULL_FILEPATH (2 * CUE_MAX_FILENAME + 2 /* two slashes*/)
 
 class SharedCUEParser : public CUEParser
 {
@@ -25,6 +52,7 @@ public:
     // switching files. This is necessary for getting the correct track
     // lengths when the .cue file references multiple .bin
     virtual const CUETrackInfo *next_track(uint64_t prev_file_size) override;
+    inline static bool test_path_len(size_t directory_len, size_t file_len) { return (directory_len + file_len + 2 /* two slashes in path name*/) <= MAX_SHARED_CUE_SHEET_SIZE;}
 
     inline static size_t max_cue_sheet_size(){ return MAX_SHARED_CUE_SHEET_SIZE;}
 protected:
@@ -32,7 +60,8 @@ protected:
     // If not, loads the correct _cue_file into the _shared_cuesheet buffer
     virtual void update_file();
     char static _shared_cuesheet[MAX_SHARED_CUE_SHEET_SIZE];
-    char static _current_file_loaded[CUE_MAX_FILENAME + 1];
-    char _cue_filepath[CUE_MAX_FILENAME + 1];
+    char static _current_file_loaded[CUE_MAX_FULL_FILEPATH + 1];
+    // max chars "/cue_max_filename-path/cue_max_filename
+    char _cue_filepath[CUE_MAX_FULL_FILEPATH + 1];
 
 };

--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -31,7 +31,7 @@
 #include <CUEParser.h>
 
 // Maximum path length for files on SD card
-#define MAX_FILE_PATH 255
+#define MAX_FILE_PATH 256
 
 namespace zuluide::images {
 

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -49,7 +49,7 @@
 #define FIRMWARE_PREFIX "ZuluIDE-FW"
 
 // Maximum path length for files on SD card
-#define MAX_FILE_PATH 255
+#define MAX_FILE_PATH 256
 
 // Transfer buffer size in bytes, must be a power of 2
 #ifndef IDE_BUFFER_SIZE

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -69,6 +69,9 @@ public:
 
     virtual void set_esn_event(esn_event_t event);
 
+    // Test if set image recorded valid tracks
+    inline bool tracks_valid() {return m_last_track.track_number > 0;}
+
 protected:
     
     virtual bool handle_atapi_command(const uint8_t *cmd);
@@ -119,7 +122,7 @@ protected:
 
     // Access data from CUE sheet, or dummy data if no cue sheet provided
     SharedCUEParser m_cueparser;
-    bool loadAndValidateCueSheet(FsFile *dir, const char *cuesheetname);
+    bool loadAndValidateCueSheet(FsFile *dir, const char *cuesheetname, CUETrackInfo &first_track, CUETrackInfo &last_track);
     bool getFirstLastTrackInfo(CUETrackInfo &first, CUETrackInfo &last);
     uint32_t getLeadOutLBA(const CUETrackInfo* lasttrack);
     CUETrackInfo getTrackFromLBA(uint32_t lba);
@@ -159,4 +162,7 @@ protected:
 
     // shared memory for when a temporary filename is need
     char m_filename[MAX_FILE_PATH + 1];
+
+    CUETrackInfo m_first_track;
+    CUETrackInfo m_last_track;
 };

--- a/src/ide_imagefile.cpp
+++ b/src/ide_imagefile.cpp
@@ -139,7 +139,14 @@ bool IDEImageFile::get_filename(char *buf, size_t buflen)
     }
     else
     {
-        m_file.getName(buf, buflen);
+        size_t name_len = m_file.getName(buf, buflen);
+        // Assume a string length that fills the buffer exactly to have been truncated
+        if (name_len == buflen - 1)
+        {
+            logmsg("IDEImageFile::get_filename(): file name too long: ", buf);
+            buf[0] = '\0';
+            return false;
+        }
         return true;
     }
 }
@@ -166,7 +173,14 @@ bool IDEImageFile::get_foldername(char *buf, size_t buflen)
         return false;
     }
 
-    m_folder.getName(buf, buflen);
+    size_t name_len = m_folder.getName(buf, buflen);
+    // Assume a string length that fills the buffer exactly to have been truncated
+    if (name_len >= buflen - 1)
+    {
+        logmsg("IDEImageFile::get_foldername(): folder name too long: ", buf);
+        buf[0] = '\0';
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
This was originally to address issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/259 when concatenating cue sheet filenames.

This adds more guard rails around the cue sheet filenames. It also doubles the length of the full file path for the SharedCUEParser So now the full path can be 255 characters for the directory and 255 characters for the CUE filename. The CUE sheet filenames and image filenames have been normalized to 255 characters for a valid filename. If the filename is 256 characters it considers the filename to have been truncated and invalidates the image.

The first and last trackinfo are now stored on the ide_cdrom.cpp class when an image is set. This reduces the need to read the CUE sheet twice on set_image() for bin/cue files. It also avoid rereading the CUE sheet on capacity_lba() and atapi_read_disc_information().

Copyright headers have been added to SharedCUEParser.