### PR TITLE
Fix CD audio playback and use CUE file handlers

### DIFF
--- a/lib/SharedCUEParser/SharedCUEParser.cpp
+++ b/lib/SharedCUEParser/SharedCUEParser.cpp
@@ -28,7 +28,8 @@
 #include <SdFat.h>
 
 extern SdFs SD;
-char SharedCUEParser::_current_file_loaded[CUE_MAX_FULL_FILEPATH + 1] = {0};
+
+FsFile * SharedCUEParser::_current_cue_file = nullptr;
 char SharedCUEParser::_shared_cuesheet[MAX_SHARED_CUE_SHEET_SIZE];
 
 static void write_default_cuesheet(char * cue_sheet)
@@ -42,79 +43,79 @@ static void write_default_cuesheet(char * cue_sheet)
 
 SharedCUEParser::SharedCUEParser()
 {
-    set("");
+    m_cue_sheet = _shared_cuesheet;
+    switch_cue();
 }
 
 SharedCUEParser::SharedCUEParser(const char* path)
 {
-    set(path);
+    m_cue_sheet = _shared_cuesheet;
+    _cue_file.open(path);
+    switch_cue();
 }
 
- void SharedCUEParser::set(const char* path)
- {
-    strlcpy(_cue_filepath, path, sizeof(_cue_filepath));
-    m_cue_sheet = _shared_cuesheet;
-    if (path[0] == '\0' && _shared_cuesheet[0] == '\0')
-    {
-        write_default_cuesheet(_shared_cuesheet);
-    }
-    restart();
- }
+FsFile *SharedCUEParser::get_cue_file()
+{
+    return &_cue_file;
+}
 
 // Restart parsing from beginning of file
 void SharedCUEParser::restart()
 {
-    update_file();
+    switch_cue();
     CUEParser::restart();
 }
 const CUETrackInfo *SharedCUEParser::next_track()
 { 
-    update_file();
+
+    switch_cue();
     return CUEParser::next_track();
 }
 
 
 const CUETrackInfo *SharedCUEParser::next_track(uint64_t prev_file_size)
 {
-    update_file();
+    switch_cue();
     return CUEParser::next_track(prev_file_size);
 }
 
-void SharedCUEParser::update_file()
+void SharedCUEParser::load_updated_cue()
 {
-    if ( strcasecmp(_cue_filepath, _current_file_loaded) != 0)
+    load_cue();
+    CUEParser::restart();
+}
+
+void SharedCUEParser::load_cue()
+{
+    if (!_cue_file.isOpen())
     {
-        strlcpy(_current_file_loaded, _cue_filepath, sizeof(_current_file_loaded));
-        // Empty filepath, load simple cuesheet
-        if (_current_file_loaded[0] == '\0')
+        write_default_cuesheet(_shared_cuesheet);
+    }
+    else
+    {
+        _cue_file.rewind();
+        int count = _cue_file.read(_shared_cuesheet, sizeof(_shared_cuesheet) - 1);
+        char filename[257];
+        _cue_file.getName(filename, sizeof(filename));
+        // on read error, close _cue_file;
+        if (count <= 0)
         {
-            write_default_cuesheet(_shared_cuesheet);
+            _cue_file.close();
         }
         else
         {
-
-            FsFile file = SD.open(_current_file_loaded);
-            if (file.isOpen())
-            {
-                int count = file.read(_shared_cuesheet, sizeof(_shared_cuesheet));
-                file.close();
-                // on read error, set _shared_cuesheet to an empty string;
-                if (count <= 0)
-                {
-                    _shared_cuesheet[0] = '\0';
-                }
-                else
-                {
-                    // Null terminate data into a valid string
-                    _shared_cuesheet[count] = '\0';
-                }
-            }
-            else
-            {
-                // on open error, set _shared_cuesheet to an empty string;
-                _shared_cuesheet[0] = '\0';
-            }
+            // Null terminate data into a valid string
+            _shared_cuesheet[count] = '\0';
         }
+    }
+}
+
+void SharedCUEParser::switch_cue()
+{
+    if ( _current_cue_file != &_cue_file)
+    {
+        _current_cue_file = &_cue_file;
+        load_cue();
     }
 }
 

--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -73,8 +73,7 @@ namespace zuluide::images {
     FsFile currentFile;
     bool is_valid_filename(const char *name, bool warning = false);
     bool fileIsValidImage(FsFile& file, const char* fileName, bool warning = false);
-    bool tryReadQueueSheet(FsFile &cuesheetfile);
-    bool searchForCueSheetFile(FsFile *directory, FsFile &outputFile);
+    bool searchForCueSheetFile(FsFile *directory, FsFile *outputFile);
     bool folderContainsCueSheet(FsFile &dir);
 
     char candidate[MAX_FILE_PATH + 1];

--- a/src/ZuluIDE_audio.h
+++ b/src/ZuluIDE_audio.h
@@ -156,7 +156,7 @@ void audio_set_file_position(uint32_t lba);
 
 /**
  * Sets the cue_parser
- * cue_parser - the cue parser in use
- * filename - the filename for the bini file for a non directory bin/cue combination
+ * cue_filename - the cue file to use
+ * filename - the filename for the bin file for a non directory bin/cue combination
  */
-void audio_set_cue_parser(CUEParser *cue_parser, FsFile *file);
+void audio_set_cue_parser(char * cue_filename, FsFile *file);


### PR DESCRIPTION
This fixes issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/263

The SharedCUEParser changes never made it to the audio cue parser, breaking audio playback. Switched the SharedCUEParser to use file handlers instead of full file paths on identifying when to reload the shared CUE sheet cache. And applied the changes to the audio cue parser loading to fix audio playback.