### PR TITLE
Fix/reset volume on CD/image change

### DIFF
--- a/lib/ZuluIDE_Audio_RP2MCU/audio.cpp
+++ b/lib/ZuluIDE_Audio_RP2MCU/audio.cpp
@@ -675,6 +675,7 @@ void audio_set_cue_parser(char *cue_file_name, FsFile* file)
 {
     // Reset volume whenever a image changes
     audio_set_volume(DEFAULT_VOLUME_LEVEL, DEFAULT_VOLUME_LEVEL);
+    audio_set_channel(AUDIO_CHANNEL_ENABLE_MASK);
     if (file != nullptr)
     {
         logmsg("Cue sheet filename: ", cue_file_name);


### PR DESCRIPTION
Some DOS games expect their volume to be reset on disc change. This fix resets the volume whenever a new CUE file is sent to the audio system. This change also re-enables volume channels on CD change. Along with the volume level being reset, the drive should re-enable the volume channels. When disabled, they are effectively muted. It seems some DOS apps expect their volume to be reset on disc change. 

Resolves Issue #265