### PR TITLE
Add identify_gencfg ini option to specify ATA IDENTIFY General Configuration value

### DIFF
--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -526,7 +526,11 @@ void IDEDevice::initialize(int devidx)
     m_devconfig.ide_heads = ini_getl("IDE", "heads", 0, CONFIGFILE);
     m_devconfig.ide_cylinders = ini_getl("IDE", "cylinders", 0, CONFIGFILE);
     m_devconfig.access_delay = ini_getl("IDE", "access_delay", 0, CONFIGFILE);
+    m_devconfig.ide_identify_gencfg = ini_getl("IDE", "identify_gencfg", 0, CONFIGFILE);
 
+    if (m_devconfig.ide_identify_gencfg)
+        logmsg("-- ATA IDENTIFY General Configuration: ", (uint16_t) m_devconfig.ide_identify_gencfg);
+    
     g_ignore_cmd_interrupt = ini_getl("IDE", "ignore_command_interrupt", 1, CONFIGFILE);
     if (!g_ignore_cmd_interrupt)
     {

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -120,6 +120,7 @@ protected:
         int ide_heads;
         int ide_sectors;
         int access_delay;
+        int ide_identify_gencfg;
     } m_devconfig;
 
     // PHY capabilities limited by active device configuration

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -541,7 +541,9 @@ bool IDERigidDevice::cmd_identify_device(ide_registers_t *regs)
      // Generic IDE hard drive
     uint64_t lba = capacity_lba();
 
-    idf[IDE_IDENTIFY_OFFSET_GENERAL_CONFIGURATION] = (m_devinfo.removable ? 0x80 : 0x40); // Device type
+    // Word 0 General Configuration - mostly depreciated in later versions of ATA-2, but some old ATA-1 hosts/drivers may expect specific values
+    idf[IDE_IDENTIFY_OFFSET_GENERAL_CONFIGURATION] = (m_devconfig.ide_identify_gencfg ? m_devconfig.ide_identify_gencfg : (m_devinfo.removable ? 0x80 : 0x40)); // Device type
+
     idf[IDE_IDENTIFY_OFFSET_NUM_CYLINDERS] = m_devinfo.cylinders;
     idf[IDE_IDENTIFY_OFFSET_NUM_HEADS] = m_devinfo.heads;
     idf[IDE_IDENTIFY_OFFSET_BYTES_PER_TRACK] = m_devinfo.bytes_per_sector * m_devinfo.sectors_per_track;

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -27,6 +27,7 @@
 # ide_model = "ide model name" # max length 40 characters
 # ide_serial = "ide serial" # max length 20 characters
 # ide_revision = "revision" # max length 8 characters
+# identify_gencfg = 0xF5A   # specify an exact response for ATA IDENTIFY DEVICE General Configuration (Word 0), required for some old ATA-1 hosts/drivers
 
 # no_media_on_init = 0 # Set to 1 for the removable drive to be empty on power up
 # no_media_on_sd_insert = 0 # Set to 1 for the removable drive to empty on SD card insertion
@@ -44,7 +45,6 @@
 # cylinders = 1024   # Override C/H/S for harddrives.
 # heads = 16         # All three must be specified, otherwise automatic guess is used.
 # sectors = 63
-
 # access_delay = 0   # Add extra delay (milliseconds) before answering to commands
 
 # max_volume = 100 # Audio max volume 0 - 100 (default)


### PR DESCRIPTION
Certain old ATA-1 hosts/driver stacks may require a specific value in General Configuration (word 0) of the IDENTIFY DRIVE response. This PR adds an ini field identify_gencfg to allow specifying this value for rigid disks only. 

This is specifically required by the Outbound Laptop (Model 125, Wallaby) which expects a value of 0xF5A.

Tested to work correctly on Outbound Laptop and should not change behavior if not specified elsewhere. I don't think a value of 0 would ever be a valid General Configuration word expected by a host, so I've used that to indicate the override is disabled / was not specified in the ini file.