### PR TITLE
Fix ejection issues for Linux and Windows

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -656,14 +656,12 @@ void status_observer(const zuluide::status::SystemStatus& current) {
     load_image(current.GetLoadedImage());
     g_ide_device->set_loaded_without_media(false);
     g_loadedFirstImage = true;
-    g_ide_device->loaded_new_media();
   }
   else if ((g_loadedFirstImage && !current.LoadedImagesAreEqual(g_previous_controller_status))) {
     // The current image has changed.
     if (current.HasLoadedImage())
     {
       load_image(current.GetLoadedImage());
-      g_ide_device->loaded_new_media();
     } 
     else
     {

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -73,7 +73,7 @@ public:
 
     virtual void insert_media(IDEImage *image = nullptr) override;
 
-    virtual void insert_next_media(IDEImage *image = nullptr) override;
+    virtual bool insert_next_media(IDEImage *image = nullptr) override;
 
     virtual inline bool set_load_deferred(const char* image_name) override {return false;}
     virtual inline bool is_load_deferred() override {return false;}
@@ -87,6 +87,8 @@ public:
     virtual inline bool is_removable() override {return m_devinfo.removable;}
 
     virtual void loaded_new_media() override;
+
+    virtual void eject_then_load_new_media() override;
 
     virtual inline bool is_loaded_without_media() override {return m_removable.loaded_without_media;}
     virtual void set_loaded_without_media(bool no_media) override;
@@ -239,5 +241,8 @@ protected:
 
     // Set not ready if enabled via config ini
     virtual void set_not_ready(bool not_ready);
+
+    // shared memory for when a temporary filename is need
+    char m_filename[MAX_FILE_PATH + 1];
 
 };

--- a/src/ide_cdrom.h
+++ b/src/ide_cdrom.h
@@ -47,9 +47,11 @@ public:
 
     virtual void insert_media(IDEImage *image = nullptr) override;
 
-    virtual void insert_next_media(IDEImage *image = nullptr) override;
+    virtual bool insert_next_media(IDEImage *image = nullptr) override;
 
     virtual void loaded_new_media() override;
+
+    virtual void eject_then_load_new_media() override;
 
     virtual void set_loaded_without_media(bool no_media) override;
 
@@ -165,9 +167,8 @@ protected:
 
     bool doPlayAudio(uint32_t lba, uint32_t length);
 
-    // shared memory for when a temporary filename is need
-    char m_filename[MAX_FILE_PATH + 1];
-
     CUETrackInfo m_first_track;
     CUETrackInfo m_last_track;
+
+    bool m_eject_then_load_cycle;
 };

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -85,8 +85,8 @@ public:
     // For removable media devices - insert current
     virtual void insert_media(IDEImage *image = nullptr) = 0;
 
-    // For removable media devices - insert next
-    virtual void insert_next_media(IDEImage *image = nullptr) = 0;
+    // For removable media devices - insert next. Return true if media was loaded
+    virtual bool insert_next_media(IDEImage *image = nullptr) = 0;
 
     // Deferred loading status
     virtual bool set_load_deferred(const char* image_name) = 0;
@@ -100,6 +100,10 @@ public:
 
     // Run when new media is loaded
     virtual void loaded_new_media() = 0;
+
+    // Run when media first needs to be ejected and then loaded
+    // Does not require loaded_new_media()
+    virtual void eject_then_load_new_media() = 0;
 
     // This is the state of media for the device at init or SD insertion
     virtual bool is_loaded_without_media() = 0;

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -72,7 +72,7 @@ public:
 
     virtual void insert_media(IDEImage *image = nullptr) override;
 
-    virtual inline void insert_next_media(IDEImage *image = nullptr) override {;}
+    virtual inline bool insert_next_media(IDEImage *image = nullptr) override {return false;}
 
     virtual inline bool set_load_deferred(const char* image_name) override {return false;}
     virtual inline bool is_load_deferred() override {return false;}
@@ -82,6 +82,7 @@ public:
     virtual inline void set_loaded_without_media(bool no_media) override{;}
 
     virtual inline void loaded_new_media() override {;}
+    virtual inline void eject_then_load_new_media() override {;}
 
     virtual inline void set_load_first_image_cb(void (*load_image_cb)()) override {;}
 protected:

--- a/src/ide_zipdrive.cpp
+++ b/src/ide_zipdrive.cpp
@@ -133,7 +133,6 @@ void IDEZipDrive::insert_media(IDEImage *image)
         if (g_ide_imagefile.open_file(img_iterator.Get().GetFilename().c_str()))
         {
             logmsg("-- Device loading media: \"", img_iterator.Get().GetFilename().c_str(), "\"");
-            m_removable.ejected = false;
             set_image(&g_ide_imagefile);
             loaded_new_media();
         }

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -8,7 +8,7 @@
 # enable_usb_mass_storage = 0 # Disabled by default, set to 1 to enable access via USB mass storage
 
 # eject_button = 1 # bit field bit 0 = GPIO_11 (default),  bit 1 = GPIO_14
-# ignore_prevent_removal = 1 # Set to 0 to respect the host's ability to block ejection
+# ignore_prevent_removal = 0 # Set to 1 to ignore the host's ability to block ejection
 # has_drive1 = 0         # Force secondary drive detection result
 
 # max_udma = 0           # Maximum UDMA mode to use, -1 to disable UDMA


### PR DESCRIPTION
It was found that eject was not working in Linux after fixing it for Windows 8. This was due to the fact that Linux locks the drive and doesn't use the Get Event Status Notification (GESN) Operational Change class but Windows does. After reorganizing the GESN code and moving ejection detection around it now works for both Windows and Linux. Also tested in Windows 98 and ejection was partially broken there. It required the eject detection code in the ATAPI Test Unit command to be above the no media error return.

The "zuluide.ini" setting `ignore_prevent_removal` default value has been change to false. This is because ejection now properly works in Linux where the OS locks the drive. It also means Zip drive emulation works with the Roland SP-808 without needing to set anything in the `zuluide.ini` file.