### PR TITLE
Add startup sound playback support

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -30,6 +30,7 @@
 #include "ZuluIDE_config.h"
 #include "ZuluIDE_platform.h"
 #include "ZuluIDE_msc.h"
+#include "ZuluIDE_audio.h"
 #include "ZuluIDE_log.h"
 #include "ide_protocol.h"
 #include "ide_cdrom.h"
@@ -799,6 +800,14 @@ void zuluide_init(void)
     // Set to ejected state if there is no media present
     g_ide_device->eject_media();
   }
+
+#ifdef STARTUPSOUND
+  if (g_sdcard_present && SD.exists(STARTUPSOUND))
+  {
+    logmsg("Playing " STARTUPSOUND);
+    audio_play_wav(STARTUPSOUND);
+  }
+#endif
 
   blinkStatus(BLINK_STATUS_OK);
   logmsg("Initialization complete!");

--- a/src/ZuluIDE_audio.h
+++ b/src/ZuluIDE_audio.h
@@ -82,6 +82,13 @@ bool audio_is_playing();
 bool audio_play(uint32_t start, uint32_t length, bool swap);
 
 /**
+ * Begin playback of a raw WAV file.
+ *
+ * Currently only stereo, 16-bit, 44100 Hz format is supported.
+ */
+bool audio_play_wav(const char *filename);
+
+/**
  * Pauses audio playback. This may be delayed slightly to allow sample buffers
  * to purge.
  *

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -69,3 +69,6 @@
 
 // Prefix for command file to create new image (case-insensitive)
 #define CREATEFILE "create"
+
+// Name of startup sound file
+#define STARTUPSOUND "startup.wav"


### PR DESCRIPTION
Mainly to simplify production testing of the sound hardware, but can be used for computer boot sounds as well.

To use, place "startup.wav" on the SD card. The wav file must have 16-bit stereo PCM format with 44100 Hz samplerate.