### PR TITLE
Fix eject from web interface

### DIFF
--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -33,7 +33,7 @@
 #include "i2c_server_src_type.h"
 #include <string>
 
-#define I2C_API_VERSION "3.0.0"
+#define I2C_API_VERSION "3.0.1"
 
 // Delay between reading the filenames off the SD card in milliseconds
 #ifndef I2C_FILENAME_TRANSFER_DELAY

--- a/lib/ZuluControl/include/zuluide/status/system_status.h
+++ b/lib/ZuluControl/include/zuluide/status/system_status.h
@@ -63,14 +63,18 @@ namespace zuluide::status {
     bool IsDeferred() const;
     void SetIsDeferred(bool defer);
 
+    bool IsEject() const;
+    void SetIsEject(bool eject);
+
     std::string ToJson() const;
   private:
     std::unique_ptr<IDeviceStatus> primary;
     std::string firmwareVersion;
     std::unique_ptr<zuluide::images::Image> loadedImage;
-    bool isPrimary;
     bool isCardPresent;
+    bool isPrimary;
     bool isPreventRemovable;
     bool isDeferred;
+    bool isEject;
   };
 }

--- a/lib/ZuluControl/src/status/status_controller.cpp
+++ b/lib/ZuluControl/src/status/status_controller.cpp
@@ -45,6 +45,7 @@ void StatusController::AddObserver(std::function<void(const SystemStatus&)> call
 
 void StatusController::EjectImage() {
   status.SetLoadedImage(nullptr);
+  status.SetIsEject(true);
   notifyObservers();
 }
 
@@ -107,6 +108,7 @@ void StatusController::LoadImage(zuluide::images::Image i) {
 void StatusController::LoadImageSafe(zuluide::images::Image i) {
   UpdateAction* actionToExecute = new UpdateAction();
   actionToExecute->ToLoad = std::make_unique<zuluide::images::Image>(i);
+  actionToExecute->IsEject = false;
   if(!updateQueue.TryAdd(&actionToExecute)) {
     logmsg("Load image failed to enqueue.");
   }
@@ -114,6 +116,7 @@ void StatusController::LoadImageSafe(zuluide::images::Image i) {
 
 void StatusController::EjectImageSafe() {
   UpdateAction* actionToExecute = new UpdateAction();
+  actionToExecute->IsEject = true;
   if(!updateQueue.TryAdd(&actionToExecute)) {
     logmsg("Eject image failed to enqueue.");
   }
@@ -126,7 +129,9 @@ void StatusController::ProcessUpdates() {
     if (actionToExecute->ToLoad) {
       LoadImage(*actionToExecute->ToLoad);
     } else {
-      EjectImage();
+      if (actionToExecute->IsEject){
+        EjectImage();
+      }
     }
    
     delete(actionToExecute);

--- a/lib/ZuluControl/src/status/status_controller.h
+++ b/lib/ZuluControl/src/status/status_controller.h
@@ -91,6 +91,7 @@ namespace zuluide::status {
       /***
           If the value is null, this is an eject.
        **/
+      bool IsEject;
       std::unique_ptr<zuluide::images::Image> ToLoad;
     };
 

--- a/lib/ZuluControl/src/status/system_status.cpp
+++ b/lib/ZuluControl/src/status/system_status.cpp
@@ -34,7 +34,7 @@ SystemStatus::SystemStatus()
 }
 
 SystemStatus::SystemStatus(const SystemStatus& src)
-  : firmwareVersion(src.firmwareVersion), isCardPresent(src.isCardPresent), isPrimary(src.isPrimary), isPreventRemovable(src.isPreventRemovable), isDeferred(src.isDeferred)
+  : firmwareVersion(src.firmwareVersion), isCardPresent(src.isCardPresent), isPrimary(src.isPrimary), isPreventRemovable(src.isPreventRemovable), isDeferred(src.isDeferred), isEject(src.isEject)
 {
   if (src.primary) {
     primary = std::move(src.primary->Clone());
@@ -54,6 +54,7 @@ SystemStatus::SystemStatus(SystemStatus&& src)
   isPrimary = src.isPrimary;
   isPreventRemovable = src.isPreventRemovable;
   isDeferred = src.isDeferred;
+  isEject = src.isEject;
 }
 
 SystemStatus& SystemStatus::operator= (SystemStatus&& src) {
@@ -64,6 +65,7 @@ SystemStatus& SystemStatus::operator= (SystemStatus&& src) {
   isPrimary = src.isPrimary;
   isPreventRemovable = src.isPreventRemovable;  
   isDeferred = src.isDeferred;
+  isEject = src.isEject;
   return *this;
 }
 
@@ -82,6 +84,7 @@ SystemStatus& SystemStatus::operator= (const SystemStatus& src) {
   isPrimary = src.isPrimary;
   isPreventRemovable = src.isPreventRemovable;
   isDeferred = src.isDeferred;
+  isEject = src.isEject;
 
   return *this;
 }
@@ -95,6 +98,8 @@ void SystemStatus::SetFirmwareVersion(std::string&& frmVer) {
 }
 
 void SystemStatus::SetLoadedImage(std::unique_ptr<zuluide::images::Image> image) {
+  if (image != nullptr)
+    isEject = false;
   loadedImage = std::move(image);
 }
 
@@ -155,6 +160,13 @@ bool SystemStatus::IsDeferred() const {
 }
 void SystemStatus::SetIsDeferred(bool defer){
   isDeferred = defer;
+}
+
+bool SystemStatus::IsEject() const {
+  return isEject;
+}
+void SystemStatus::SetIsEject(bool eject) {
+  isEject = eject;
 }
 
 static const char* toString(bool value) {

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -653,7 +653,11 @@ void clear_image() {
 
 void status_observer(const zuluide::status::SystemStatus& current) {
   // We need to check and see what changes have occurred.
-  if (g_ide_device->is_loaded_without_media() && current.HasLoadedImage()) {
+  if (!current.HasLoadedImage() && current.IsEject())
+  {
+    g_ide_device->button_eject_media();
+  }
+  else if (g_ide_device->is_loaded_without_media() && current.HasLoadedImage()) {
 
     load_image(current.GetLoadedImage());
     g_ide_device->set_loaded_without_media(false);

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -67,9 +67,9 @@ public:
 
     virtual void eject_button_poll(bool immediate);
 
-    virtual void button_eject_media();
+    virtual void button_eject_media() override;
 
-    virtual void eject_media();
+    virtual void eject_media() override;
 
     virtual void insert_media(IDEImage *image = nullptr) override;
 

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -51,6 +51,8 @@ public:
     // polls eject buttons status
     virtual void eject_button_poll(bool immediate) = 0;
 
+    virtual void button_eject_media() {;}
+
     virtual void eject_media() {;}
 
     // device medium is present


### PR DESCRIPTION
An update to eject behavior broke the web interface eject button. This commit should fix the issue reported here: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/278
A change was made in the web interface but the web API itself didn't change. As such there was a minor bump to the web API version 3.0.0 to 3.0.1 on the web interface side. This side, server side, has also made the API version change to match.