### PR TITLE
Fix loading the same image after eject via web

### DIFF
--- a/lib/ZuluControl/src/status/system_status.cpp
+++ b/lib/ZuluControl/src/status/system_status.cpp
@@ -79,6 +79,10 @@ SystemStatus& SystemStatus::operator= (const SystemStatus& src) {
   if (src.loadedImage) {
     loadedImage = std::make_unique<zuluide::images::Image>(*src.loadedImage);
   }
+  else
+  {
+    loadedImage = nullptr;
+  }
 
   isCardPresent = src.isCardPresent;
   isPrimary = src.isPrimary;


### PR DESCRIPTION
This fixes the issue where the same image won't reload after and eject via the web interface. Reported on issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/281

It was due to the fact copy operator of SystemStatus wasn't copying over the nullptr state of the image pointer when saving the previous state. Thus after attempting the load the same image after an eject the firmware would see the pointer as the same and assume nothing needed to be changed.

Setting the image pointer to null on an eject properly compares the previous state and the new state as being different and loads the image again.