### PR TITLE
Fix extended delay in the ATA protocol polling loop

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/rp2040_ide_phy.cpp
+++ b/lib/ZuluIDE_platform_RP2040/rp2040_ide_phy.cpp
@@ -80,7 +80,7 @@ static ide_phy_capabilities_t g_ide_phy_capabilities = {
 };
 
 // Reset the IDE phy
-void ide_phy_reset(const ide_phy_config_t* config)
+void ide_phy_config(const ide_phy_config_t* config)
 {
     g_ide_phy.config = *config;
     g_ide_phy.watchdog_error = false;
@@ -94,6 +94,15 @@ void ide_phy_reset(const ide_phy_config_t* config)
     if (config->disable_iordy)       cfg |= 0x20;
     if (config->enable_packet_intrq) cfg |= 0x40;
     fpga_wrcmd(FPGA_CMD_SET_IDE_PHY_CFG, &cfg, 1);
+}
+
+// Reset the IDE phy
+void ide_phy_reset()
+{
+    ide_phy_stop_transfers();
+    uint8_t clear_all_mask = 0xFF;
+    fpga_wrcmd(FPGA_CMD_CLR_IRQ_FLAGS, &clear_all_mask, 1);
+    g_ide_phy.watchdog_error = false;
 }
 
 void ide_phy_reset_from_watchdog()
@@ -121,7 +130,7 @@ ide_event_t ide_phy_get_events()
 
     if (g_ide_phy.watchdog_error)
     {
-        ide_phy_reset(&g_ide_phy.config);
+        ide_phy_reset();
         return IDE_EVENT_HWRST;
     }
     else if (status & FPGA_STATUS_IDE_RST)

--- a/src/ide_phy.h
+++ b/src/ide_phy.h
@@ -66,7 +66,10 @@ struct ide_phy_config_t {
 };
 
 // Reset the IDE phy
-void ide_phy_reset(const ide_phy_config_t* config);
+void ide_phy_config(const ide_phy_config_t* config);
+
+// Reset the IDE phy that has already been configured
+void ide_phy_reset();
 
 // Print debug information to log, called when something goes wrong
 void ide_phy_print_debug();

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -68,7 +68,7 @@ static bool g_ide_reset_after_init_done;
 
 bool g_ignore_cmd_interrupt;
 
-static void do_phy_reset()
+static void do_phy_config()
 {
     if (g_ide_devices[1] == NULL)
     {
@@ -103,7 +103,6 @@ static void do_phy_reset()
     g_ide_config.enable_packet_intrq = ini_getbool("IDE", "atapi_intrq", default_intrq, CONFIGFILE);
     g_ide_config.disable_iocs16 = ini_getbool("IDE", "disable_iocs16", false, CONFIGFILE);
 
-
     if (g_ide_config.enable_dev0 && g_ide_config.enable_dev1_zeros)
     {
         dbgmsg("-- IDE PHY reset, operating as primary drive without secondary drive");
@@ -121,7 +120,7 @@ static void do_phy_reset()
         dbgmsg("-- IDE PHY reset, operating as two drives");
     }
 
-    ide_phy_reset(&g_ide_config);
+    ide_phy_config(&g_ide_config);
 }
 
 const ide_phy_config_t *ide_protocol_get_config()
@@ -137,7 +136,7 @@ void ide_protocol_init(IDEDevice *primary, IDEDevice *secondary)
     if (primary) primary->initialize(0);
     if (secondary) secondary->initialize(1);
 
-    do_phy_reset();
+    do_phy_config();
     g_ide_reset_after_init_done = false;
 }
 
@@ -255,7 +254,7 @@ void ide_protocol_poll()
                 // \todo move to a reset or init function
                 g_exec_dev_diag_state = EXEC_DEV_DIAG_STATE_IDLE;
 
-                do_phy_reset();
+                ide_phy_reset();
 
                 if (g_ide_devices[1])
                 {
@@ -377,7 +376,7 @@ void ide_protocol_poll()
 
                         // Apply configuration based on whether drive1 was present
                         g_drive1_detected = detected;
-                        do_phy_reset();
+                        do_phy_config();
                     }
 
                     g_last_reset_event = IDE_EVENT_NONE;


### PR DESCRIPTION
A USB to IDE device was failing due to a long delay in the ide_protocol.cpp polling loop that handled HW and SW resets.

ZuluIDE needs to be able to respond within 2ms after a hardware or software IDE reset according to the ATA spec. There were a two 1ms delays in ide_phy_reset() which exceeded the 2ms along with the code path execution time handling either IDE reset.

The function ZuluIDE V2 ide_phy_reset() 1ms delays have been reduced to 100us and the configuration part of it was moved to ide_phy_config().

Configuration and reset have also been split on the ZuluIDE RP2040. On reset stopping transfers and clearing IRQ flags have been added to match what the V2 does.

The USB to IDE adapter now works fine.