### PR TITLE
V2-specific (RP2350B) fix for device detection under Linux and some other controllers

### DIFF
--- a/lib/ZuluIDE_platform_RP2350/rp2350_ide_phy.cpp
+++ b/lib/ZuluIDE_platform_RP2350/rp2350_ide_phy.cpp
@@ -79,7 +79,7 @@ void ide_phy_config(const ide_phy_config_t* config)
     if (g_rp2350_passive_sniffer) return;
 
     g_idecomm.enable_idephy = false;
-    sleep_us(100);
+    busy_wait_us_32(CORE1_RESPONSE_DELAY);
 
     // Only initialize registers once after boot, after that ide_protocol handles it.
     static bool regs_inited = false;
@@ -118,7 +118,7 @@ void ide_phy_config(const ide_phy_config_t* config)
 
     g_idecomm.enable_idephy = true;
 
-    sleep_us(100);
+    busy_wait_us_32(CORE1_RESPONSE_DELAY);
     core1_log_poll();
 
     if (g_idecomm.requests & CORE1_REQ_SET_REGS)
@@ -132,7 +132,7 @@ void ide_phy_reset()
     if (g_rp2350_passive_sniffer) return;
 
     g_idecomm.enable_idephy = false;
-    sleep_us(100);
+    busy_wait_us_32(CORE1_RESPONSE_DELAY);
     phy_ide_registers_t phyregs = g_idecomm.phyregs;
     __sync_synchronize();
 
@@ -146,7 +146,7 @@ void ide_phy_reset()
 
     g_idecomm.enable_idephy = true;
 
-    sleep_us(100);
+    busy_wait_us_32(CORE1_RESPONSE_DELAY);
     core1_log_poll();
 
     if (g_idecomm.requests & CORE1_REQ_SET_REGS)
@@ -198,7 +198,7 @@ ide_event_t ide_phy_get_events()
     if (flags & CORE1_EVT_HWRST)
     {
         ide_phy_clear_event(CORE1_EVT_HWRST);
-        sleep_us(100);
+        busy_wait_us_32(CORE1_RESPONSE_DELAY);
         if (g_idecomm.events & CORE1_EVT_HWRST)
         {
             // Reset still continues, report when it ends
@@ -211,7 +211,6 @@ ide_event_t ide_phy_get_events()
     }
     else if ((flags & CORE1_EVT_SWRST) || g_ide_phy.watchdog_error)
     {
-        return IDE_EVENT_HWRST;
         // Software reset
         ide_phy_clear_event(CORE1_EVT_SWRST);
         g_ide_phy.watchdog_error = false;
@@ -481,7 +480,7 @@ uint8_t ide_phy_get_signals()
     {
         last_poll = time_now;
         ide_phy_post_request(CORE1_REQ_GET_SIGNALS);
-        sleep_us(10);
+        busy_wait_us_32(CORE1_RESPONSE_DELAY);
     }
 
     return g_idecomm.get_signals;

--- a/lib/ZuluIDE_platform_RP2350/zuluide_rp2350b_core1.h
+++ b/lib/ZuluIDE_platform_RP2350/zuluide_rp2350b_core1.h
@@ -32,6 +32,13 @@
 // it is busy handling previous requests.
 #define CORE1_REQ_BUSY              0x80000000
 
+// Amount of delay core 0 should wait before getting
+// or setting values for core 1
+#ifndef CORE1_RESPONSE_DELAY
+#define CORE1_RESPONSE_DELAY 100
+#endif
+
+
 typedef struct {
     ide_registers_t regs;
     int state_irqreq: 1; // Interrupt is being asserted to host


### PR DESCRIPTION
A errant `return IDE_EVENT_HWRST;` was added to the commit 4753230973dd45e962ce34fb120ce327f6b6545d in ide_phy_get_events().

This was causing the event not clear and the wrong code path being executed. Removing the line fixed the issue.

Also swapped sleeps in the busy_waits in `rp2350_ide_phy.cpp` and changed the hard coded value into a C macro `CORE1_RESPONSE_DELAY`.