### PR TITLE
Disable audio when sniffer is active

### DIFF
--- a/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.cpp
@@ -1070,6 +1070,11 @@ mutex_t* platform_get_log_mutex() {
 
 bool platform_enable_sniffer(const char *filename, bool passive)
 {
+#ifdef ENABLE_AUDIO_OUTPUT
+    logmsg("-- Disabling audio to enable sniffer");
+    audio_disable();
+#endif
+
     if (passive)
     {
         // Stop IDE phy and configure pins for passive input


### PR DESCRIPTION
The sniffer and the audio PIO state machines share the same PIO, the audio I2S PIO also is on the upper 16-47 GPIOs so there is no way they can be compatible with each other. This fix unloads the audio I2S PIO when the sniffer is enabled so the sniffer can capture data again.