### PR TITLE
Speed up ZuluIDE init

### DIFF
--- a/lib/ZuluUSB/ZuluSerialUSB.cpp
+++ b/lib/ZuluUSB/ZuluSerialUSB.cpp
@@ -1,0 +1,253 @@
+/*
+    Serial-Over-USB for the Raspberry Pi Pico RP2040
+    Implements an ACM which will reboot into UF2 mode on a 1200bps DTR toggle.
+    Much of this was modified from the Raspberry Pi Pico SDK stdio_usb.c file.
+
+    Copyright (c) 2021 Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#if defined(NO_USB)
+
+#include <Arduino.h>
+#include <tusb.h>
+#include "CoreMutex.h"
+#include "USB.h"
+#include "SerialUSB.h"
+
+
+// SerialEvent functions are weak, so when the user doesn't define them,
+// the linker just sets their address to 0 (which is checked below).
+// The Serialx_available is just a wrapper around Serialx.available(),
+// but we can refer to it weakly so we don't pull in the entire
+// HardwareSerial instance if the user doesn't also refer to it.
+extern void serialEvent() __attribute__((weak));
+
+#define USBD_CDC_CMD_MAX_SIZE (8)
+#define USBD_CDC_IN_OUT_MAX_SIZE (64)
+
+
+
+SerialUSB::SerialUSB() {
+}
+
+void SerialUSB::begin(unsigned long baud) {
+    (void) baud; //ignored
+
+    if (_running) {
+        return;
+    }
+
+    USB.disconnect();
+
+    _epIn = USB.registerEndpointIn();
+    _epOut = USB.registerEndpointOut();
+    _epIn2 = USB.registerEndpointIn();
+    _strID = USB.registerString("Pico Serial");
+
+    _id = USB.registerInterface(2, _cb, (void *)this, TUD_CDC_DESC_LEN, 1, 0);
+
+    USB.connect();
+    _running = true;
+}
+
+// Need to define here so we don't have to include tusb.h in global header (causes problemw w/BT redefining things)
+void SerialUSB::interfaceCB(int itf, uint8_t *dst, int len) {
+    uint8_t desc[TUD_CDC_DESC_LEN] = {
+        TUD_CDC_DESCRIPTOR((uint8_t)itf, _strID, _epIn, USBD_CDC_CMD_MAX_SIZE, _epOut, _epIn2, USBD_CDC_IN_OUT_MAX_SIZE)
+    };
+    memcpy(dst, desc, len);
+};
+
+void SerialUSB::end() {
+    if (_running) {
+        USB.disconnect();
+        USB.unregisterInterface(_id);
+        USB.unregisterEndpointIn(_epIn);
+        USB.unregisterEndpointOut(_epOut);
+        _running = false;
+        USB.connect();
+    }
+}
+
+int SerialUSB::peek() {
+    CoreMutex m(&USB.mutex, false);
+    if (!_running || !m) {
+        return 0;
+    }
+
+    uint8_t c;
+    tud_task();
+    return tud_cdc_peek(&c) ? (int) c : -1;
+}
+
+int SerialUSB::read() {
+    CoreMutex m(&USB.mutex, false);
+    if (!_running || !m) {
+        return -1;
+    }
+
+    tud_task();
+    if (tud_cdc_available()) {
+        return tud_cdc_read_char();
+    }
+    return -1;
+}
+
+int SerialUSB::available() {
+    CoreMutex m(&USB.mutex, false);
+    if (!_running || !m) {
+        return 0;
+    }
+
+    tud_task();
+    return tud_cdc_available();
+}
+
+int SerialUSB::availableForWrite() {
+    CoreMutex m(&USB.mutex, false);
+    if (!_running || !m) {
+        return 0;
+    }
+
+    tud_task();
+    return tud_cdc_write_available();
+}
+
+void SerialUSB::flush() {
+    CoreMutex m(&USB.mutex, false);
+    if (!_running || !m) {
+        return;
+    }
+
+    tud_cdc_write_flush();
+    tud_task();
+}
+
+size_t SerialUSB::write(uint8_t c) {
+    return write(&c, 1);
+}
+
+size_t SerialUSB::write(const uint8_t *buf, size_t length) {
+    CoreMutex m(&USB.mutex, false);
+    if (!_running || !m) {
+        return 0;
+    }
+
+    static uint64_t last_avail_time;
+    int written = 0;
+    if (tud_cdc_connected() || _ss.ignoreFlowControl) {
+        for (size_t i = 0; i < length;) {
+            int n = length - i;
+            int avail = tud_cdc_write_available();
+            if (n > avail) {
+                n = avail;
+            }
+            if (n) {
+                int n2 = tud_cdc_write(buf + i, n);
+                tud_task();
+                tud_cdc_write_flush();
+                i += n2;
+                written += n2;
+                last_avail_time = time_us_64();
+            } else {
+                tud_task();
+                tud_cdc_write_flush();
+                if (!tud_cdc_connected() ||
+                        (!tud_cdc_write_available() && time_us_64() > last_avail_time + 1'000'000 /* 1 second */)) {
+                    break;
+                }
+            }
+        }
+    } else {
+        // reset our timeout
+        last_avail_time = 0;
+    }
+    tud_task();
+    return written;
+}
+
+SerialUSB::operator bool() {
+    CoreMutex m(&USB.mutex, false);
+    if (!_running || !m) {
+        return false;
+    }
+
+    tud_task();
+    return tud_cdc_connected();
+}
+
+void SerialUSB::ignoreFlowControl(bool ignore) {
+    _ss.ignoreFlowControl = ignore;
+}
+
+void SerialUSB::checkSerialReset() {
+    if (!_ss.rebooting && (_ss.bps == 1200) && (!_ss.dtr)) {
+#ifdef __FREERTOS
+        __freertos_idle_other_core();
+#endif
+        _ss.rebooting = true;
+        // Disable NVIC IRQ, so that we don't get bothered anymore
+        irq_set_enabled(USBCTRL_IRQ, false);
+        // Reset the whole USB hardware block
+        reset_block(RESETS_RESET_USBCTRL_BITS);
+        unreset_block(RESETS_RESET_USBCTRL_BITS);
+        // Delay a bit, so the PC can figure out that we have disconnected.
+        busy_wait_ms(3);
+        reset_usb_boot(0, 0);
+        while (1); // WDT will fire here
+    }
+}
+
+bool SerialUSB::dtr() {
+    return _ss.dtr;
+}
+
+bool SerialUSB::rts() {
+    return _ss.rts;
+}
+
+extern "C" void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
+    Serial.tud_cdc_line_state_cb(itf, dtr, rts);
+}
+
+void SerialUSB::tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
+    (void) itf;
+    _ss.dtr = dtr ? 1 : 0;
+    _ss.rts = rts ? 1 : 0;
+    checkSerialReset();
+}
+
+extern "C" void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* p_line_coding) {
+    Serial.tud_cdc_line_coding_cb(itf, (void const *)p_line_coding);
+}
+
+void SerialUSB::tud_cdc_line_coding_cb(uint8_t itf, void const *p) {
+    (void) itf;
+    cdc_line_coding_t const* p_line_coding = (cdc_line_coding_t const*)p;
+    _ss.bps = p_line_coding->bit_rate;
+    checkSerialReset();
+}
+
+SerialUSB Serial;
+
+void arduino::serialEventRun(void) {
+    if (serialEvent && Serial.available()) {
+        serialEvent();
+    }
+}
+
+#endif

--- a/lib/ZuluUSB/ZuluUSB.cpp
+++ b/lib/ZuluUSB/ZuluUSB.cpp
@@ -1,0 +1,750 @@
+/*
+    Shared USB for the Raspberry Pi Pico RP2040
+    Allows for multiple endpoints to share the USB controller
+
+    Copyright (c) 2021 Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#if defined(NO_USB)
+
+#include <Arduino.h>
+#include "CoreMutex.h"
+#include "USB.h"
+
+#include <tusb.h>
+#include <device/usbd_pvt.h>
+#include <class/hid/hid_device.h>
+#include <pico/time.h>
+#include <hardware/irq.h>
+#include <pico/mutex.h>
+#include <pico/unique_id.h>
+#include <pico/usb_reset_interface.h>
+#include <hardware/watchdog.h>
+
+#ifdef __FREERTOS
+#include "FreeRTOS.h"
+#include "task.h"
+#include "timers.h"
+#include "semphr.h"
+#endif
+
+USBClass USB;
+
+// USB processing will be a periodic timer task
+#define USB_TASK_INTERVAL 1000
+
+#ifndef USBD_VID
+#define USBD_VID (0x2E8A) // Raspberry Pi
+#endif
+
+#ifndef USBD_PID
+#define USBD_PID (0x000a) // Raspberry Pi Pico SDK CDC
+#endif
+
+#ifdef ENABLE_PICOTOOL_USB
+#define TUD_RPI_RESET_DESCRIPTOR(_itfnum, _stridx) \
+  /* Interface */\
+  9, TUSB_DESC_INTERFACE, _itfnum, 0, 0, TUSB_CLASS_VENDOR_SPECIFIC, RESET_INTERFACE_SUBCLASS, RESET_INTERFACE_PROTOCOL, _stridx,
+uint8_t _picotool_itf_num;
+#endif
+
+int usb_hid_poll_interval __attribute__((weak)) = 10;
+
+uint8_t USBClass::registerEndpointIn() {
+    if (!_endpointIn) {
+        return 0; // ERROR, out of EPs
+    }
+    int firstFree = __builtin_ctz(_endpointIn);
+    _endpointIn &= ~(1 << firstFree);
+    return 0x80 + firstFree;
+}
+
+void USBClass::unregisterEndpointIn(int ep) {
+    _endpointIn |= 1 << ep;
+}
+
+uint8_t USBClass::registerEndpointOut() {
+    if (!_endpointOut) {
+        return 0; // ERROR, out of EPs
+    }
+    int firstFree = __builtin_ctz(_endpointOut);
+    _endpointOut &= ~(1 << firstFree);
+    return firstFree;
+}
+
+void USBClass::unregisterEndpointOut(int ep) {
+    _endpointOut |= (1 << (ep - 0x80));
+}
+
+uint8_t USBClass::addEntry(Entry **head, int interfaces, void (*cb)(int itf, uint8_t *dst, int len, void *param), const void *param, size_t len, int ordering, uint32_t pidMask) {
+    static uint8_t id = 1;
+
+    Entry *n = (Entry *)malloc(sizeof(Entry));
+    n->cb = cb;
+    n->param = param;
+    n->len = len;
+    n->interfaces = interfaces;
+    n->order = ordering;
+    n->localid = id++;
+    n->mask = pidMask;
+    n->next = nullptr;
+
+    // Go down list until we hit the end or an entry with ordering >= our level
+    Entry *prev = nullptr;
+    Entry *cur = *head;
+    while (cur && (ordering > cur->order)) {
+        prev = cur;
+        cur = cur->next;
+    }
+    if (!prev) {
+        n->next = *head;
+        *head = n;
+    } else if (!cur) {
+        prev->next = n;
+    } else {
+        n->next = cur;
+        prev->next = n;
+    }
+    return n->localid;
+}
+
+void USBClass::removeEntry(Entry **head, unsigned int localid) {
+    Entry *prev = nullptr;
+    Entry *cur = *head;
+    while (cur && cur->localid != localid) {
+        prev = cur;
+        cur = cur->next;
+    }
+    if (!cur) {
+        // Not found, just exit
+        return;
+    }
+    if (cur == *head) {
+        auto p = cur->next;
+        free(*head);
+        *head = p;
+    } else {
+        prev->next = cur->next;
+        free(cur);
+    }
+}
+
+// Find the index (HID report ID or USB interface) of a given localid
+unsigned int USBClass::findID(Entry *head, unsigned int localid) {
+    unsigned int x = 0;
+    while (head && head->localid != localid) {
+        x += head->interfaces;
+        head = head->next;
+    }
+    return x;
+}
+
+uint8_t USBClass::findHIDReportID(unsigned int localid) {
+    return findID(_hids, localid) + 1; // HID reports start at 1
+}
+
+uint8_t USBClass::findInterfaceID(unsigned int localid) {
+    return findID(_interfaces, localid);
+}
+
+// Called by a HID device to register a report.  Returns the *local* ID which must be mapped to the HID report ID
+uint8_t USBClass::registerHIDDevice(const uint8_t *descriptor, size_t len, int ordering, uint32_t pidMask) {
+    return addEntry(&_hids, 1, nullptr, (const void *)descriptor, len, ordering, pidMask);
+}
+
+void USBClass::unregisterHIDDevice(unsigned int localid) {
+    removeEntry(&_hids, localid);
+}
+
+// Called by an object at global init time to add a new interface (non-HID, like CDC or Picotool)
+uint8_t USBClass::registerInterface(int interfaces, void (*cb)(int itf, uint8_t *dst, int len, void *), void *param, size_t len, int ordering, uint32_t pidMask) {
+    return addEntry(&_interfaces, interfaces, cb, param, len, ordering, pidMask);
+}
+
+void USBClass::unregisterInterface(unsigned int localid) {
+    removeEntry(&_interfaces, localid);
+}
+
+uint8_t USBClass::registerString(const char *str) {
+    if (usbd_desc_str_alloc <= usbd_desc_str_cnt) {
+        usbd_desc_str_alloc += 4;
+        usbd_desc_str = (const char **)realloc(usbd_desc_str, usbd_desc_str_alloc * sizeof(usbd_desc_str[0]));
+    }
+
+    if (!usbd_desc_str_cnt) {
+        usbd_desc_str[0] = "";
+        usbd_desc_str_cnt++;
+    }
+    // Don't re-add strings that already exist
+    for (size_t i = 0; i < usbd_desc_str_cnt; i++) {
+        if (!strcmp(str, usbd_desc_str[i])) {
+            return i;
+        }
+    }
+    usbd_desc_str[usbd_desc_str_cnt] = str;
+    return usbd_desc_str_cnt++;
+}
+
+void USBClass::setVIDPID(uint16_t vid, uint16_t pid) {
+    _forceVID = vid;
+    _forcePID = pid;
+}
+
+void USBClass::setManufacturer(const char *str) {
+    _forceManuf = USB.registerString(str);
+}
+
+void USBClass::setProduct(const char *str) {
+    _forceProd = USB.registerString(str);
+}
+
+void USBClass::setSerialNumber(const char *str) {
+    _forceSerial = USB.registerString(str);
+}
+
+const uint8_t *USBClass::tud_descriptor_device_cb() {
+    static char idString[PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 3 + 1];
+    if (!idString[0]) {
+        pico_get_unique_board_id_string(idString, sizeof(idString));
+    }
+
+    usbd_desc_device = {
+        .bLength = sizeof(tusb_desc_device_t),
+        .bDescriptorType = TUSB_DESC_DEVICE,
+#ifdef ENABLE_PICOTOOL_USB
+        .bcdUSB = 0x210,
+#else
+        .bcdUSB = 0x0200,
+#endif
+        .bDeviceClass = 0xef, //0,
+        .bDeviceSubClass = 0x02, //0,
+        .bDeviceProtocol = 0x01, //0,
+        .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+        .idVendor = _forceVID ? _forceVID : (uint16_t)USBD_VID,
+        .idProduct = _forcePID ? _forcePID : (uint16_t)USBD_PID,
+        .bcdDevice = 0x0100,
+        .iManufacturer = _forceManuf ? _forceManuf : USB.registerString(USB_MANUFACTURER),
+        .iProduct = _forceProd ? _forceProd : USB.registerString(USB_PRODUCT),
+        .iSerialNumber = _forceSerial ? _forceSerial : USB.registerString(idString),
+        .bNumConfigurations = 1
+    };
+
+    // Handle any inversions from the sub-devices, if we're not forcing things
+    if (!_forcePID) {
+        Entry *h = _hids;
+        while (h) {
+            usbd_desc_device.idProduct ^= h->mask;
+            h = h->next;
+        }
+        h = _interfaces;
+        while (h) {
+            usbd_desc_device.idProduct ^= h->mask;
+            h = h->next;
+        }
+    }
+
+    return (const uint8_t *)&usbd_desc_device;
+}
+
+const uint8_t *tud_descriptor_device_cb() {
+    return USB.tud_descriptor_device_cb();
+}
+
+uint8_t *USBClass::getDescHIDReport(int *len) {
+    if (len) {
+        *len = _hid_report_len;
+    }
+    return _hid_report;
+}
+
+void USBClass::setupDescHIDReport() {
+    _hid_report_len = 0;
+    Entry *h = _hids;
+    while (h) {
+        _hid_report_len += h->len;
+        h = h->next;
+    }
+
+    // No HID used at all
+    if (_hid_report_len == 0) {
+        _hid_report = nullptr;
+        return;
+    }
+
+    // Allocate the "real" HID report descriptor
+    _hid_report = (uint8_t *)malloc(_hid_report_len);
+
+    // Now copy the descriptors
+    uint8_t *p = _hid_report;
+    uint8_t id = 1;
+    h = _hids;
+    while (h) {
+        memcpy(p, h->param, h->len);
+        // Need to update the report ID, a 2-byte value
+        char buff[] = { HID_REPORT_ID(id) };
+        memcpy(p + 6, buff, sizeof(buff));
+        p += h->len;
+        id++;
+        h = h->next;
+    }
+}
+
+// Invoked when received GET HID REPORT DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance) {
+    return USB.tud_hid_descriptor_report_cb(instance);
+}
+
+uint8_t const *USBClass::tud_hid_descriptor_report_cb(uint8_t instance) {
+    (void) instance;
+    return getDescHIDReport(nullptr);
+}
+
+const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
+    return USB.tud_descriptor_configuration_cb(index);
+}
+
+const uint8_t *USBClass::tud_descriptor_configuration_cb(uint8_t index) {
+    (void)index;
+    return USB.usbd_desc_cfg;
+}
+
+// Build the binary image of the complete USB descriptor
+// Note that we can add stack-allocated descriptors here because we know
+// we're going to use them before the function exits and they'll not be
+// needed ever again
+void USBClass::setupUSBDescriptor() {
+    uint8_t interface_count = 0;
+    if (usbd_desc_cfg) {
+        return;
+    }
+
+    int hid_report_len;
+    if (getDescHIDReport(&hid_report_len)) {
+        uint8_t hid_desc[TUD_HID_DESC_LEN] = {
+            // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
+            TUD_HID_DESCRIPTOR(1 /* placeholder*/, 0, HID_ITF_PROTOCOL_NONE, hid_report_len, _hid_endpoint = USB.registerEndpointIn(), CFG_TUD_HID_EP_BUFSIZE, (uint8_t)usb_hid_poll_interval)
+        };
+        _hid_interface = USB.registerInterface(1, simpleInterface, hid_desc, sizeof(hid_desc), 10, 0);
+    }
+
+#ifdef ENABLE_PICOTOOL_USB
+    uint8_t picotool_desc[] = { TUD_RPI_RESET_DESCRIPTOR(1, USB.registerString("Reset")) };
+    _picotool_itf_num = USB.registerInterface(1, simpleInterface, picotool_desc, sizeof(picotool_desc), 100, 0);
+#endif
+
+    usbd_desc_cfg_len = TUD_CONFIG_DESC_LEN; // Always have a config descriptor
+    Entry *h = _interfaces;
+    while (h) {
+        usbd_desc_cfg_len += h->len;
+        interface_count += h->interfaces;
+        h = h->next;
+    }
+
+    uint8_t tud_cfg_desc[TUD_CONFIG_DESC_LEN] = {
+        // Config number, interface count, string index, total length, attribute, power in mA
+        TUD_CONFIG_DESCRIPTOR(1, interface_count, USB.registerString(""), usbd_desc_cfg_len, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, USBD_MAX_POWER_MA)
+    };
+
+    // Allocate the "real" report descriptor
+    usbd_desc_cfg = (uint8_t *)malloc(usbd_desc_cfg_len);
+    bzero(usbd_desc_cfg, usbd_desc_cfg_len);
+
+    // Now copy the interface descriptors
+    h = _interfaces;
+    uint8_t *p = usbd_desc_cfg;
+    memcpy(p, tud_cfg_desc, sizeof(tud_cfg_desc));
+    p += sizeof(tud_cfg_desc);
+    int id = 0;
+    while (h) {
+        h->cb(id, p, h->len, (void *)h->param);
+        p += h->len;
+        id += h->interfaces;
+        h = h->next;
+    }
+}
+
+const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
+    return USB.tud_descriptor_string_cb(index, langid);
+}
+
+const uint16_t *USBClass::tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
+    (void) langid;
+#define DESC_STR_MAX (32)
+    static uint16_t desc_str[DESC_STR_MAX];
+    uint8_t len;
+    if (index == 0) {
+        desc_str[1] = 0x0409; // supported language is English
+        len = 1;
+    } else {
+        if (index >= usbd_desc_str_cnt) {
+            return nullptr;
+        }
+        const char *str = usbd_desc_str[index];
+        for (len = 0; len < DESC_STR_MAX - 1 && str[len]; ++len) {
+            desc_str[1 + len] = str[len];
+        }
+    }
+
+    // first byte is length (including header), second byte is string type
+    desc_str[0] = (TUSB_DESC_STRING << 8) | (2 * len + 2);
+
+    return desc_str;
+}
+
+#ifdef __FREERTOS
+void USBClass::freertosUSBTask(void *param) {
+    (void) param;
+
+    Serial.begin(115200);
+
+    USB.initted = true;
+
+    while (true) {
+        BaseType_t ss = xTaskGetSchedulerState();
+        if (ss != taskSCHEDULER_SUSPENDED) {
+            auto m = __get_freertos_mutex_for_ptr(&USB.mutex);
+            if (xSemaphoreTake(m, 0)) {
+                tud_task();
+                xSemaphoreGive(m);
+            }
+        }
+        vTaskDelay(1 / portTICK_PERIOD_MS);
+    }
+}
+#else
+void USBClass::usbIRQ() {
+    // if the mutex is already owned, then we are in user code
+    // in this file which will do a tud_task itself, so we'll just do nothing
+    // until the next tick; we won't starve
+    if (mutex_try_enter(&USB.mutex, nullptr)) {
+        tud_task();
+        mutex_exit(&USB.mutex);
+    }
+}
+
+int64_t USBClass::timerTask(__unused alarm_id_t id, __unused void *user_data) {
+    irq_set_pending(USB.usbTaskIRQ);
+    return USB_TASK_INTERVAL;
+}
+#endif
+
+void USBClass::disconnect() {
+    bool wasConnected = tud_connected();
+#ifdef __FREERTOS
+    auto m = __get_freertos_mutex_for_ptr(&USB.mutex);
+    xSemaphoreTake(m, portMAX_DELAY);
+    tud_disconnect();
+    if (wasConnected) {
+        vTaskDelay(500 / portTICK_PERIOD_MS);
+    }
+    xSemaphoreGive(m);
+#else
+    mutex_enter_blocking(&USB.mutex);
+    tud_disconnect();
+    if (wasConnected) {
+        sleep_ms(500);
+    }
+    mutex_exit(&USB.mutex);
+#endif
+    // Ensure when we reconnect we make the new descriptor
+    free(usbd_desc_cfg);
+    usbd_desc_cfg = nullptr;
+    usbd_desc_cfg_len = 0;
+    if (_hid_report) {
+        unregisterInterface(_hid_interface);
+        unregisterEndpointIn(_hid_endpoint);
+    }
+    free(_hid_report);
+    _hid_report = nullptr;
+    _hid_report_len = 0;
+#ifdef ENABLE_PICOTOOL_USB
+    unregisterInterface(_picotool_itf_num);
+#endif
+}
+
+void USBClass::connect()  {
+    setupDescHIDReport();
+    setupUSBDescriptor();
+
+#ifdef __FREERTOS
+    auto m = __get_freertos_mutex_for_ptr(&USB.mutex);
+    xSemaphoreTake(m, portMAX_DELAY);
+    tud_connect();
+    xSemaphoreGive(m);
+#else
+    mutex_enter_blocking(&USB.mutex);
+    tud_connect();
+    mutex_exit(&USB.mutex);
+#endif
+}
+
+void USBClass::begin() {
+    if (tusb_inited()) {
+        // Already called
+        return;
+    }
+
+    setupDescHIDReport();
+    setupUSBDescriptor();
+
+    mutex_init(&mutex);
+
+    tusb_init();
+
+#ifdef __FREERTOS
+    // Make high prio and locked to core 0
+    TaskHandle_t usbTask;
+    xTaskCreate(freertosUSBTask, "USB", 256, 0, configMAX_PRIORITIES - 2, &usbTask);
+    vTaskCoreAffinitySet(usbTask, 1 << 0);
+#else
+    usbTaskIRQ = user_irq_claim_unused(true);
+    irq_set_exclusive_handler(usbTaskIRQ, usbIRQ);
+    irq_set_enabled(usbTaskIRQ, true);
+    add_alarm_in_us(USB_TASK_INTERVAL, timerTask, nullptr, true);
+#endif
+}
+
+
+bool USBClass::HIDReady() {
+    uint32_t start = millis();
+    const uint32_t timeout = 500;
+
+    while (((millis() - start) < timeout) && tud_ready() && !tud_hid_ready()) {
+        tud_task();
+        delayMicroseconds(1);
+    }
+    return tud_hid_ready();
+}
+
+
+// Invoked when received GET_REPORT control request
+// Application must fill buffer report's content and return its length.
+// Return zero will cause the stack to STALL request
+extern "C" uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) __attribute__((weak));
+extern "C" uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) {
+    // TODO not implemented
+    (void) instance;
+    (void) report_id;
+    (void) report_type;
+    (void) buffer;
+    (void) reqlen;
+
+    return 0;
+}
+
+// Invoked when received SET_REPORT control request or
+// received data on OUT endpoint ( Report ID = 0, Type = 0 )
+extern "C" void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) __attribute__((weak));
+extern "C" void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) {
+    // TODO set LED based on CAPLOCK, NUMLOCK etc...
+    (void) instance;
+    (void) report_id;
+    (void) report_type;
+    (void) buffer;
+    (void) bufsize;
+}
+
+extern "C" int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) __attribute__((weak));
+extern "C" int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
+    (void) lun;
+    (void) lba;
+    (void) offset;
+    (void) buffer;
+    (void) bufsize;
+    return -1;
+}
+
+extern "C" bool tud_msc_test_unit_ready_cb(uint8_t lun) __attribute__((weak));
+extern "C" bool tud_msc_test_unit_ready_cb(uint8_t lun) {
+    (void) lun;
+    return false;
+}
+
+extern "C" int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) __attribute__((weak));
+extern "C" int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
+    (void) lun;
+    (void) lba;
+    (void) offset;
+    (void) buffer;
+    (void) bufsize;
+    return -1;
+}
+
+extern "C" int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize) __attribute__((weak));
+extern "C" int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize) {
+    (void) lun;
+    (void) scsi_cmd;
+    (void) buffer;
+    (void) bufsize;
+    return 0;
+}
+
+extern "C" void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size) __attribute__((weak));
+extern "C" void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size) {
+    (void) lun;
+    *block_count = 0;
+    *block_size = 0;
+}
+
+extern "C" void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) __attribute__((weak));
+extern "C" void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {
+    (void) lun;
+    vendor_id[0] = 0;
+    product_id[0] = 0;
+    product_rev[0] = 0;
+}
+
+
+
+#ifdef ENABLE_PICOTOOL_USB
+// Support for Microsoft OS 2.0 descriptor
+#define BOS_TOTAL_LEN      (TUD_BOS_DESC_LEN + TUD_BOS_MICROSOFT_OS_DESC_LEN)
+
+#define MS_OS_20_DESC_LEN  166
+#define USBD_ITF_RPI_RESET 2
+
+uint8_t const desc_bos[] = {
+    // total length, number of device caps
+    TUD_BOS_DESCRIPTOR(BOS_TOTAL_LEN, 1),
+
+    // Microsoft OS 2.0 descriptor
+    TUD_BOS_MS_OS_20_DESCRIPTOR(MS_OS_20_DESC_LEN, 1)
+};
+
+TU_VERIFY_STATIC(sizeof(desc_bos) == BOS_TOTAL_LEN, "Incorrect size");
+
+static uint32_t _itf_num = 0;
+uint8_t const * tud_descriptor_bos_cb(void) {
+    return desc_bos;
+}
+
+
+bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request) {
+    static const uint8_t desc_ms_os_20[] = {
+        // Set header: length, type, windows version, total length
+        U16_TO_U8S_LE(0x000A), U16_TO_U8S_LE(MS_OS_20_SET_HEADER_DESCRIPTOR), U32_TO_U8S_LE(0x06030000), U16_TO_U8S_LE(MS_OS_20_DESC_LEN),
+
+        // Function Subset header: length, type, first interface, reserved, subset length
+        U16_TO_U8S_LE(0x0008), U16_TO_U8S_LE(MS_OS_20_SUBSET_HEADER_FUNCTION), USB.findInterfaceID(_picotool_itf_num), 0, U16_TO_U8S_LE(0x009C),
+
+        // MS OS 2.0 Compatible ID descriptor: length, type, compatible ID, sub compatible ID
+        U16_TO_U8S_LE(0x0014), U16_TO_U8S_LE(MS_OS_20_FEATURE_COMPATBLE_ID), 'W', 'I', 'N', 'U', 'S', 'B', 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sub-compatible
+
+        // MS OS 2.0 Registry property descriptor: length, type
+        U16_TO_U8S_LE(0x0080), U16_TO_U8S_LE(MS_OS_20_FEATURE_REG_PROPERTY),
+        U16_TO_U8S_LE(0x0001), U16_TO_U8S_LE(0x0028), // wPropertyDataType, wPropertyNameLength and PropertyName "DeviceInterfaceGUID" in UTF-16
+        'D', 0x00, 'e', 0x00, 'v', 0x00, 'i', 0x00, 'c', 0x00, 'e', 0x00, 'I', 0x00, 'n', 0x00, 't', 0x00, 'e', 0x00,
+        'r', 0x00, 'f', 0x00, 'a', 0x00, 'c', 0x00, 'e', 0x00, 'G', 0x00, 'U', 0x00, 'I', 0x00, 'D', 0x00, 0x00, 0x00,
+        U16_TO_U8S_LE(0x004E), // wPropertyDataLength
+        // Vendor-defined Property Data: {bc7398c1-73cd-4cb7-98b8-913a8fca7bf6}
+        '{', 0,     'b', 0,     'c', 0,     '7', 0,     '3', 0,     '9', 0,
+        '8', 0,     'c', 0,     '1', 0,     '-', 0,     '7', 0,     '3', 0,
+        'c', 0,     'd', 0,     '-', 0,     '4', 0,     'c', 0,     'b', 0,
+        '7', 0,     '-', 0,     '9', 0,     '8', 0,     'b', 0,     '8', 0,
+        '-', 0,     '9', 0,     '1', 0,     '3', 0,     'a', 0,     '8', 0,
+        'f', 0,     'c', 0,     'a', 0,     '7', 0,     'b', 0,     'f', 0,
+        '6', 0,     '}', 0,       0, 0
+    };
+
+    TU_VERIFY_STATIC(sizeof(desc_ms_os_20) == MS_OS_20_DESC_LEN, "Incorrect size");
+    // nothing to with DATA & ACK stage
+    if (stage != CONTROL_STAGE_SETUP) {
+        return true;
+    }
+
+    if (request->bRequest == 1 && request->wIndex == 7) {
+        // Get Microsoft OS 2.0 compatible descriptor
+        return tud_control_xfer(rhport, request, (void*)(uintptr_t) desc_ms_os_20, sizeof(desc_ms_os_20));
+    } else {
+        return false;
+    }
+
+    // stall unknown request
+    return false;
+}
+
+
+static void resetd_init(void) {
+}
+
+static void resetd_reset(uint8_t __unused rhport) {
+    _itf_num = 0;
+}
+
+static uint16_t resetd_open(uint8_t __unused rhport, tusb_desc_interface_t const *itf_desc, uint16_t max_len) {
+    TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == itf_desc->bInterfaceClass &&
+              RESET_INTERFACE_SUBCLASS == itf_desc->bInterfaceSubClass &&
+              RESET_INTERFACE_PROTOCOL == itf_desc->bInterfaceProtocol, 0);
+
+    uint16_t const drv_len = sizeof(tusb_desc_interface_t);
+    TU_VERIFY(max_len >= drv_len, 0);
+
+    _itf_num = itf_desc->bInterfaceNumber;
+    return drv_len;
+}
+
+// Support for parameterized reset via vendor interface control request
+static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_control_request_t const * request) {
+    // nothing to do with DATA & ACK stage
+    if (stage != CONTROL_STAGE_SETUP) {
+        return true;
+    }
+
+    if (request->wIndex == _itf_num) {
+        if (request->bRequest == RESET_REQUEST_BOOTSEL) {
+            int gpio = -1;
+            bool active_low = false;
+            rom_reset_usb_boot_extra(gpio, (request->wValue & 0x7f), active_low);
+            // does not return, otherwise we'd return true
+        }
+        if (request->bRequest == RESET_REQUEST_FLASH) {
+            watchdog_reboot(0, 0, 10);
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool resetd_xfer_cb(uint8_t __unused rhport, uint8_t __unused ep_addr, xfer_result_t __unused result, uint32_t __unused xferred_bytes) {
+    return true;
+}
+
+static usbd_class_driver_t const _resetd_driver = {
+#if CFG_TUSB_DEBUG >= 2
+    .name = "RESET",
+#endif
+    .init             = resetd_init,
+    .reset            = resetd_reset,
+    .open             = resetd_open,
+    .control_xfer_cb  = resetd_control_xfer_cb,
+    .xfer_cb          = resetd_xfer_cb,
+    .sof              = NULL
+};
+
+// Implement callback to add our custom driver
+usbd_class_driver_t const *usbd_app_driver_get_cb(uint8_t *driver_count) {
+    *driver_count = 1;
+    return &_resetd_driver;
+}
+
+#endif
+
+
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ lib_deps =
     ZuluControl
     ZuluIDE_Audio_RP2MCU
     ZuluIDE_MSC_RP2MCU
+    ZuluUSB
     ZuluIDE_platform_RP2040
     CUEParser=https://github.com/rabbitholecomputing/CUEParser#virtualize
     adafruit/Adafruit BusIO
@@ -44,6 +45,7 @@ build_flags =
     -DENABLE_DEDICATED_SPI=1
     -DHAS_SDIO_CLASS
     -DUSE_ARDUINO=1
+    -DNO_USB
     -DPLATFORM_MASS_STORAGE
     -DSSD1306_NO_SPLASH
     -DENABLE_AUDIO_OUTPUT
@@ -67,9 +69,11 @@ lib_deps =
     ZuluControl
     ZuluIDE_Audio_RP2MCU
     ZuluIDE_MSC_RP2MCU
+    ZuluUSB
     ZuluIDE_platform_RP2350
     SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
     CUEParser=https://github.com/rabbitholecomputing/CUEParser#virtualize
+    TinyUSB=https://github.com/hathach/tinyusb#0.20.0
     adafruit/Adafruit GFX Library
     adafruit/Adafruit BusIO
     adafruit/Adafruit SSD1306
@@ -91,6 +95,7 @@ build_flags =
     -DENABLE_DEDICATED_SPI=1
     -DHAS_SDIO_CLASS
     -DUSE_ARDUINO=1
+    -DNO_USB
     -DPLATFORM_MASS_STORAGE
     -DRP2040_ARDUINO_DISABLE_CORE1=1
     -DARM_NONSECURE_MODE=1
@@ -119,6 +124,7 @@ build_flags =
     -DENABLE_DEDICATED_SPI=1
     -DHAS_SDIO_CLASS
     -DUSE_ARDUINO=1
+    -DNO_USB
     -DPLATFORM_MASS_STORAGE
     -DRP2040_ARDUINO_DISABLE_CORE1=1
     -DRP2040_DISABLE_BOOTLOADER=1

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -51,6 +51,8 @@
 #include "control/std_display_controller.h"
 #include "control/control_interface.h"
 #include "ZuluIDE_create_image.h"
+#include "USB.h"
+#include "SerialUSB.h"
 
 #include <zip_parser.h>
 bool g_sdcard_present;
@@ -797,6 +799,8 @@ void zuluide_init(void)
   platform_late_init();
   zuluide_setup_sd_card();
   zuluide_reload_config();
+  USB.begin();
+  Serial.begin(115200);
 
 #ifdef PLATFORM_MASS_STORAGE
   static bool check_mass_storage = true;


### PR DESCRIPTION
Initialization was taking seconds to load an image:
Previous firmware:
```
[315ms] Platform: ZuluIDE V2
[315ms] FW Version: 2026.02.12-release Feb 12 2026 18:09:15
[316ms] DIP switch settings: cablesel 0, drive_id 0 debug log 0
...
[516ms] -- Ignoring "#########", file extension .cue is in the reject list
[1518ms] -- Loading last used image: "#########"
...
[1539ms] Initialization complete!
[2048ms] Max volume set to 100/100
```

New firmware:
```
[315ms] Platform: ZuluIDE V2
[315ms] FW Version: 2026.02.17-release Feb 17 2026 20:18:52
[315ms] DIP switch settings: cablesel 0, drive_id 0 debug log 0
...
[515ms] -- Ignoring "#########", file extension .cue is in the reject list
[518ms] -- Loading last used image: "#########"
...
[538ms] Initialization complete!
[553ms] Max volume set to 100/100
```
Note: 
- "Initialization complete!" is the last output from the setup function
- "Max volume set to 100/100" is the first output from the main loop that services IDE ATA commands.

Changes to speed up IDE initialization
- [Change readByteUntil() to read()](https://github.com/ZuluIDE/ZuluIDE-firmware/commit/990249e4aa852a09ac4f298840375c60b4f74851) - this cut down about a 1 second delay in setup
- [Avoid a 500ms delay in USB Arduino-Pico framework](https://github.com/ZuluIDE/ZuluIDE-firmware/commit/7e6fc580cf95cc5a584b2d8e54bd99e873214512) - this cut down the delay by about 500 ms between setup and the device being ready