### PR TITLE
Constant time init - WIP

### DIFF
--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -33,7 +33,7 @@
 #include "i2c_server_src_type.h"
 #include <string>
 
-#define I2C_API_VERSION "3.0.1"
+#define I2C_API_VERSION "3.1.0"
 
 // Delay between reading the filenames off the SD card in milliseconds
 #ifndef I2C_FILENAME_TRANSFER_DELAY
@@ -49,6 +49,8 @@
 #define I2C_SERVER_SSID 0xD
 #define I2C_SERVER_SSID_PASS 0xE
 #define I2C_SERVER_RESET 0xF
+#define I2C_SERVER_STATIC_IP 0x10
+#define I2C_SERVER_IP_ADDRESS_ACK 0x11
 
 #define I2C_CLIENT_NOOP 0x0
 
@@ -112,6 +114,18 @@ namespace zuluide::i2c {
     */
     void SetPassword(std::string &value);
     /**
+       Stores the Wifi static IPv4 to be passed ot the I2C client.
+    */
+    void SetIPv4(std::string &value);
+    /**
+       Stores the Wifi static IP netmask to be passed ot the I2C client.
+    */
+    void SetNetmask(std::string &value);
+    /**
+       Stores the Wifi static IP gateway to be passed ot the I2C client.
+    */
+    void SetGateway(std::string &value);
+    /**
        Sends a reset command to the I2C client. Returns true if the send is
        succesful, otherwise false.
      */
@@ -168,6 +182,9 @@ namespace zuluide::i2c {
     std::string status;
     std::string ssid;
     std::string password;
+    std::string ip;
+    std::string netmask;
+    std::string gateway;
     unsigned long remoteMajorVersion;
     std::string remoteVersionString;
   };

--- a/lib/ZuluControl/include/zuluide/images/image_iterator.h
+++ b/lib/ZuluControl/include/zuluide/images/image_iterator.h
@@ -40,6 +40,10 @@ namespace zuluide::images {
   public:
     ImageIterator();
     Image Get();
+
+    // Find a valid image without needing a Reset, not in alphanumeric order nor is filecount set
+    // if filename is a string, find that image, if it is nullptr find the first valid image
+    Image QuickGet(const char *filename = nullptr);
     // Find the next image
     // return false if there is no image or there is no next image
     bool MoveNext();

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -48,12 +48,7 @@
 #include <Wire.h>
 #include <Adafruit_SSD1306.h>
 #include "ZuluIDE_platform_gpio.h"
-#include "display/display_ssd1306.h"
-#include "rotary_control.h"
-#include <zuluide/i2c/i2c_server.h>
-#include <zuluide/i2c/i2c_server_src_type.h>
-#include <zuluide/pipe/image_response.h>
-#include <zuluide/control/select_controller_src_type.h>
+#include <ZuluControl_platform.h>
 
 #include <minIni.h>
 
@@ -73,21 +68,10 @@ static bool g_led_disabled = false;
 static bool g_led_blinking = false;
 static bool g_dip_drive_id, g_dip_cable_sel;
 static uint64_t g_flash_unique_id;
-static zuluide::control::RotaryControl g_rotary_input;
 static TwoWire g_wire(GPIO_I2C_DEVICE, GPIO_I2C_SDA, GPIO_I2C_SCL);
-static zuluide::DisplaySSD1306 display;
 static uint8_t g_eject_buttons = 0;
 
-
-
-static zuluide::pipe::ImageResponsePipe<zuluide::control::select_controller_source_t>* g_controllerImageResponsePipe;
-
-static zuluide::pipe::ImageResponsePipe<zuluide::i2c::i2c_server_source_t> g_I2CServerImageResponsePipe;
-static zuluide::pipe::ImageRequestPipe<zuluide::i2c::i2c_server_source_t> g_I2CServerImageRequestPipe;
-static zuluide::i2c::I2CServer g_I2cServer(&g_I2CServerImageRequestPipe, &g_I2CServerImageResponsePipe);
 static mutex_t logMutex;
-static zuluide::ObserverTransfer<zuluide::status::SystemStatus> *uiStatusController;
-void processStatusUpdate(const zuluide::status::SystemStatus &update);
 
 //void mbed_error_hook(const mbed_error_ctx * error_context);
 
@@ -300,82 +284,6 @@ void platform_late_init()
 #endif
     platform_check_for_controller();
     USB.begin();
-}
-
-uint8_t platform_check_for_controller()
-{
-  static bool checked = false;
-  static uint8_t controller_found = 0;
-  if (checked) return controller_found;
-  g_wire.setClock(100000);
-  // Setting the drive strength seems to help the I2C bus with the Pico W controller and the controller OLED display
-  // to communicate and handshake properly
-  gpio_set_drive_strength(GPIO_I2C_SCL, GPIO_DRIVE_STRENGTH_12MA);
-  gpio_set_drive_strength(GPIO_I2C_SDA, GPIO_DRIVE_STRENGTH_12MA);
-
-  g_rotary_input.SetI2c(&g_wire);
-  bool hasHardwareUI = g_rotary_input.CheckForDevice();
-  g_I2cServer.SetI2c(&g_wire);
-  bool hasI2CServer = g_I2cServer.CheckForDevice();
-  logmsg(hasHardwareUI ? "Hardware UI found." : "Hardware UI not found.");
-  logmsg(hasI2CServer ? "I2C server found" : "I2C server not found");
-  if(hasI2CServer)
-  {
-    g_I2CServerImageRequestPipe.Reset();
-    g_I2CServerImageResponsePipe.Reset();
-    g_I2CServerImageRequestPipe.AddObserver([&](zuluide::pipe::ImageRequest<zuluide::i2c::i2c_server_source_t> t){g_I2CServerImageResponsePipe.HandleRequest(t);});
-  }
-  controller_found = (hasHardwareUI ? CONTROLLER_TYPE_BOARD : 0) | (hasI2CServer ? CONTROLLER_TYPE_WIFI : 0);
-  checked = true;
-  return controller_found;
-}
-
-void platform_set_status_controller(zuluide::ObserverTransfer<zuluide::status::SystemStatus> *statusController) {
-  logmsg("Initialized platform controller with the status controller.");
-  display.init(&g_wire);
-  statusController->AddObserver(processStatusUpdate);
-  uiStatusController = statusController;
-}
-
-void platform_set_controller_image_response_pipe(zuluide::pipe::ImageResponsePipe<zuluide::control::select_controller_source_t> *imageRequestPipe) {
-    logmsg("Initialized platform with filename request pipe");
-    g_controllerImageResponsePipe = imageRequestPipe;
-}
-
-void platform_set_display_controller(zuluide::Observable<zuluide::control::DisplayState>& displayController) {
-  logmsg("Initialized platform controller with the display controller.");
-  displayController.AddObserver([&] (auto current) -> void {display.HandleUpdate(current);});  
-}
-
-void platform_set_input_interface(zuluide::control::InputReceiver* inputReceiver) {
-  logmsg("Initialized platform controller with input receiver.");
-  g_rotary_input.SetReceiver(inputReceiver);
-  g_rotary_input.StartSendingEvents();
-}
-
-void platform_set_device_control(zuluide::status::DeviceControlSafe* deviceControl) {
-  logmsg("Initialized platform with device control.");
-  char iniBuffer[100];
-  memset(&iniBuffer, 0, 100);
-  if (ini_gets("UI", "wifissid", "", iniBuffer, sizeof(iniBuffer), CONFIGFILE) > 0) {
-    auto ssid = std::string(iniBuffer);
-    g_I2cServer.SetSSID(ssid);
-    logmsg("Set SSID from INI file to ", ssid.c_str());
-  }
-
-  memset(&iniBuffer, 0, 100);
-  if (ini_gets("UI", "wifipassword", "", iniBuffer, sizeof(iniBuffer), CONFIGFILE) > 0) {
-    auto wifiPass = std::string(iniBuffer);
-    g_I2cServer.SetPassword(wifiPass);
-    logmsg("Set PASSWORD from INI file.");
-  }
-
-  if ((platform_check_for_controller() & CONTROLLER_TYPE_WIFI) && !g_I2cServer.WifiCredentialsSet()) {
-    // The I2C server responded but we cannot configure wifi. This may cause issues.
-    logmsg("An I2C client was detected but the WIFI credentials are not configured. This will cause problems if the I2C client needs WIFI configuration data.");
-  }
-
-  g_I2cServer.SetDeviceControl(deviceControl);
 }
 
 void platform_poll_input() {
@@ -1150,12 +1058,4 @@ void zuluide_main_loop1(void)
 
 mutex_t* platform_get_log_mutex() {
   return &logMutex;
-}
-
-void processStatusUpdate(const zuluide::status::SystemStatus &currentStatus) {
-  // Notify the hardware UI of updates.
-  display.HandleUpdate(currentStatus);
-  
-  // Notify the I2C server of updates.
-  g_I2cServer.HandleUpdate(currentStatus);
 }

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
@@ -114,41 +114,11 @@ typedef void (*sd_callback_t)(uint32_t bytes_complete);
 void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 
 /**
-   Attempts to determine whether the hardware UI or the web service is attached to the device.
- */
-uint8_t platform_check_for_controller();
-
-/**
-   Sets the status controller connection used to process status events on the UI core.
- */
-void platform_set_status_controller(zuluide::ObserverTransfer<zuluide::status::SystemStatus> *statusController);
-
-/**
-   Sets the display controller, the component tracking the state of the user interface.
- */
-void platform_set_display_controller(zuluide::Observable<zuluide::control::DisplayState>& displayController);
-
-/**
-   Sets the controller that is used by the UI to change the system state.
- */
-void platform_set_device_control(zuluide::status::DeviceControlSafe* deviceControl);
-
-/**
-   Sets the filename request pipe that is used by controllers to request filenames from a different core safely.
- */
-void platform_set_controller_image_response_pipe(zuluide::pipe::ImageResponsePipe<zuluide::control::select_controller_source_t> *imageResponsePipe);
-
-/**
    This mutex is used to prevent saving the log file to the SD card while reading the file system.
    A more robust file access method is needed, but this is fixing the problem for now, even though
    it is rather ham-handed.
  */
 mutex_t* platform_get_log_mutex();
-
-/**
-   Sets the input receiver, which handles receiving input from the hardware UI and performs updates to the UI as appropriate.
- */
-void platform_set_input_interface(zuluide::control::InputReceiver* inputReceiver);
 
 /**
    Used to poll the input hardware.

--- a/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.cpp
@@ -26,6 +26,7 @@
 #include "ZuluIDE_platform.h"
 #include "ZuluIDE_log.h"
 #include "ZuluIDE_config.h"
+#include <ZuluControl_platform.h>
 #include <ZuluIDE.h>
 #include "ide_phy.h"
 #include <SdFat.h>
@@ -843,6 +844,23 @@ void core1_log_poll()
             logmsg("CORE1: ", linebuf);
         }
     }
+}
+
+void platform_poll_input() {
+    g_rotary_input.Poll();
+
+    if (uiStatusController)
+    {
+        // Process status update, if any exist.
+        if (!uiStatusController->ProcessUpdate()) {
+            // If no updates happend, refresh the display (enables animation)
+            display.Refresh();
+        }
+
+        g_controllerImageResponsePipe->ProcessUpdates();
+        g_I2cServer.Poll();
+    }
+    g_I2CServerImageRequestPipe.ProcessUpdates();
 }
 
 // Poll function that is called every few milliseconds.

--- a/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.h
+++ b/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.h
@@ -117,41 +117,11 @@ typedef void (*sd_callback_t)(uint32_t bytes_complete);
 void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 
 /**
-   Attempts to determine whether the hardware UI or the web service is attached to the device.
- */
-uint8_t platform_check_for_controller();
-
-/**
-   Sets the status controller connection used to process status events on the UI core.
- */
-void platform_set_status_controller(zuluide::ObserverTransfer<zuluide::status::SystemStatus> *statusController);
-
-/**
-   Sets the display controller, the component tracking the state of the user interface.
- */
-void platform_set_display_controller(zuluide::Observable<zuluide::control::DisplayState>& displayController);
-
-/**
-   Sets the controller that is used by the UI to change the system state.
- */
-void platform_set_device_control(zuluide::status::DeviceControlSafe* deviceControl);
-
-/**
-   Sets the filename request pipe that is used by controllers to request filenames from a different core safely.
- */
-void platform_set_controller_image_response_pipe(zuluide::pipe::ImageResponsePipe<zuluide::control::select_controller_source_t> *imageResponsePipe);
-
-/**
    This mutex is used to prevent saving the log file to the SD card while reading the file system.
    A more robust file access method is needed, but this is fixing the problem for now, even though
    it is rather ham-handed.
  */
 mutex_t* platform_get_log_mutex();
-
-/**
-   Sets the input receiver, which handles receiving input from the hardware UI and performs updates to the UI as appropriate.
- */
-void platform_set_input_interface(zuluide::control::InputReceiver* inputReceiver);
 
 /**
    Used to poll the input hardware.

--- a/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.h
+++ b/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.h
@@ -1,0 +1,71 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2026 Rabbit Hole Computing™
+ *
+ * ZuluIDE™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Under Section 7 of GPL version 3, you are granted additional
+ * permissions described in the ZuluIDE Hardware Support Library Exception
+ * (GPL-3.0_HSL_Exception.md), as published by Rabbit Hole Computing™.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+#include <rotary_control.h>
+#include <zuluide/observer_transfer.h>
+#include <zuluide/status/system_status.h>
+#include <display/display_ssd1306.h>
+#include <zuluide/pipe/image_response_pipe.h>
+#include <zuluide/pipe/image_request_pipe.h>
+#include <zuluide/control/select_controller_src_type.h>
+#include <zuluide/i2c/i2c_server.h>
+
+extern zuluide::control::RotaryControl g_rotary_input;
+extern zuluide::ObserverTransfer<zuluide::status::SystemStatus> *uiStatusController;
+extern zuluide::DisplaySSD1306 display;
+extern zuluide::pipe::ImageResponsePipe<zuluide::control::select_controller_source_t>* g_controllerImageResponsePipe;
+extern zuluide::pipe::ImageResponsePipe<zuluide::i2c::i2c_server_source_t> g_I2CServerImageResponsePipe;
+extern zuluide::pipe::ImageRequestPipe<zuluide::i2c::i2c_server_source_t> g_I2CServerImageRequestPipe;
+extern zuluide::i2c::I2CServer g_I2cServer;
+
+/**
+   Attempts to determine whether the hardware UI or the web service is attached to the device.
+ */
+uint8_t platform_check_for_controller();
+
+/**
+   Sets the status controller connection used to process status events on the UI core.
+ */
+void platform_set_status_controller(zuluide::ObserverTransfer<zuluide::status::SystemStatus> *statusController);
+
+/**
+   Sets the display controller, the component tracking the state of the user interface.
+ */
+void platform_set_display_controller(zuluide::Observable<zuluide::control::DisplayState>& displayController);
+
+/**
+   Sets the controller that is used by the UI to change the system state.
+ */
+void platform_set_device_control(zuluide::status::DeviceControlSafe* deviceControl);
+
+/**
+   Sets the filename request pipe that is used by controllers to request filenames from a different core safely.
+ */
+void platform_set_controller_image_response_pipe(zuluide::pipe::ImageResponsePipe<zuluide::control::select_controller_source_t> *imageResponsePipe);
+
+ /**
+   Sets the input receiver, which handles receiving input from the hardware UI and performs updates to the UI as appropriate.
+ */
+void platform_set_input_interface(zuluide::control::InputReceiver* inputReceiver);
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ lib_deps =
     ZuluIDE_MSC_RP2MCU
     ZuluUSB
     ZuluIDE_platform_RP2040
+    ZuluIDE_platform_RP2MCU
     CUEParser=https://github.com/rabbitholecomputing/CUEParser#virtualize
     adafruit/Adafruit BusIO
     adafruit/Adafruit SSD1306
@@ -71,6 +72,7 @@ lib_deps =
     ZuluIDE_MSC_RP2MCU
     ZuluUSB
     ZuluIDE_platform_RP2350
+    ZuluIDE_platform_RP2MCU
     SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
     CUEParser=https://github.com/rabbitholecomputing/CUEParser#virtualize
     TinyUSB=https://github.com/hathach/tinyusb#0.20.0

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -29,6 +29,8 @@
 # ide_revision = "revision" # max length 8 characters
 # identify_gencfg = 0xF5A   # specify an exact response for ATA IDENTIFY DEVICE General Configuration (Word 0), required for some old ATA-1 hosts/drivers
 
+# skip_firmware_update = 0 # Set to 1 for bootloader to skip checking for .bin firmware update file - shortens init time you have lots of images on the SD card
+
 # no_media_on_init = 0 # Set to 1 for the removable drive to be empty on power up
 # no_media_on_sd_insert = 0 # Set to 1 for the removable drive to empty on SD card insertion
 # reinsert_media_after_eject = 1 # Automatically reinsert media after eject
@@ -36,6 +38,16 @@
 # reinsert_media_on_sd_insert = 0 # Set to 1 to reinsert media when the SD card is inserted after eject
 # set_not_ready_on_insert = 0 # Set to 1 to have the next ATAPI command report not ready - may help with some OSes detecting a CD change
 # init_with_last_used_image = 1 # Enabled by default, initialize with the last image used before power off
+
+### For constant time initialization, if there are a lot of images on the SD card.
+### Try:
+# skip_firmware_update = 1
+# no_media_on_init = 1
+### or
+# skip_firmware_update = 1
+# init_with_last_used_image = 1
+### making sure the last used image exist on SD card
+### otherwise the ZuluIDE init will be delayed searching for the first image alphanumerically
 
 # quiet_image_parsing = 0 # Do not log image parsing warnings and info when SD card is inserted
 
@@ -56,8 +68,15 @@
 # sniffer = 2     # Enable IDE bus sniffer in passive mode, ZuluIDE monitors other devices but doesn't communicate
 
 [UI]
-# An additional Pico W is required to utilize this experimental functionality, which is not yet generally available.
+### An additional Pico W is required to utilize this experimental functionality, which is not yet generally available.
 # wifipassword="MY_PASSWORD" # Password for the WIFI network.
-# Any non-alphanumeric characters in the password must be in double quotes, as per the example above
+### Any non-alphanumeric characters in the password must be in double quotes, as per the example above
 # wifissid="MY_NETWORK_SSID" # SSID for the WIFI network
+
+### Static IP Example
+# wifi_static_ip="192.168.1.42"
+# wifi_static_netmask="255.255.255.0"
+# wifi_static_gateway="192.168.1.1"
+### if none of the above exist, the WiFi enabled control board shield defaults to DHCP
+
 # rotary_encoder_ticks = 1 # number of ticks/detents before the controller board registers turning of the rotary dial


### PR DESCRIPTION
ZuluIDE initialization process takes longer with more images on the SD card. This is due to finding the first image to load, the image iterator has to compare all images alphabetically before it can find the first one. Also the bootloader has to search for the first image that matches the the proper .bin filename for firmware updates.

Now there is a way initialize the ZuluIDE without the init time scaling with the number of images. To do this two things must be set. First the bootloader must skip searching for the .bin file. To do this set the zuluide.ini file setting:
```
[IDE]
skip_firmware_update = 1
```
This will effectively disable firmware updating via .bin file via the SD card. To reenable updating, delete this setting or set it to 0.

Note: to use this feature, ZuluIDE's with firmware version `v2026.02.17` or earlier must be updated via copying the latest UF2 file version of the firmware with the bootloader button held down when connected to a USB cable on a host computer.

The second thing is to either use the init_with_last_used_image with a valid image or set no_media_on_init to 1.

init_with_last_used_image is on by default. This will create a `zululast.txt` file and it must point to valid image. If the `zululast.txt` doesn't exist or it points to a file that no longer exist, the ZuluIDE init time will grow with the number of files on the SD card again. A simple way to ensure `zululast.txt` is valid is to power cycle the ZuluIDE. This will set `zululast.txt` file to first image it loads and so the next power on the init time will be constant time.

the other options is to set
```
[IDE]
no_media_on_init = 1
```
This will start the ZuluIDE as an empty drive on power on.

These two settings should allow 100s of images to live on the SD card without increasing init time.

The other feature in this commit is WiFi enabled shields can now use static IPs for controlling CD images via the web interface. Set the wifi_static settings under the [UI] header with your own network settings in the `zuluide.ini` file. If none of the setting are in the `zuluide.ini` file or they are all commented out, the shield will default to DHCP and you can find the IP in the `zululog.txt` file or use the USB virtual COM port serial interface.

Here is an example:
```
[UI]
wifi_static_ip="192.168.1.42"
wifi_static_netmask="255.255.255.0"
wifi_static_gateway="192.168.1.1"
```

On connection the static IP should be logged to both the `zululog.txt` file and the virtual COM port. The I2C protocol version has been bumped up to version 3.1.0 to match the shield with the new static IP commands.

Common code between the two Raspberry Pi MCU targets has been moved to ZuluIDE_platform_RP2MCU. Specifically the ZuluControl_platform.cpp file from the RP2350 target library and redundant code from the RP2040 ZuluIDE_platform.cpp file has been deleted.