### PR TITLE
Prioritize media with prefixed device types

### DIFF
--- a/lib/ZuluControl/include/zuluide/images/image.h
+++ b/lib/ZuluControl/include/zuluide/images/image.h
@@ -57,6 +57,7 @@ namespace zuluide::images {
     static drive_type_t ToDriveType(const ImageType toConvert);
     static const char* GetImagePrefix(const ImageType toConvert);
     static ImageType InferImageTypeFromImagePrefix(const char* prefix);
+    static ImageType InferImageTypeFromExtension(const char *filename);
     static ImageType InferImageTypeFromFileName(const char *filename);
 
   private:

--- a/lib/ZuluControl/src/images/image.cpp
+++ b/lib/ZuluControl/src/images/image.cpp
@@ -184,21 +184,33 @@ const char* Image::GetImagePrefix(const ImageType toConvert) {
 }
 
 Image::ImageType Image::InferImageTypeFromImagePrefix(const char* prefix) {
-  if (strncasecmp(prefix, "cdrm", sizeof("cdrm")) == 0) {
+  if (       strncasecmp(prefix, "cdrm", 4) == 0) {
     return Image::ImageType::cdrom;
-  } else if (strncasecmp(prefix, "zipd", sizeof("zipd")) == 0) {
+  } else if (strncasecmp(prefix, "zipd", 4) == 0) {
     return Image::ImageType::zip100;
-  } else if (strncasecmp(prefix, "z100", sizeof("z100")) == 0) {
+  } else if (strncasecmp(prefix, "z100", 4) == 0) {
     return Image::ImageType::zip100;
-  } else if (strncasecmp(prefix, "z250", sizeof("z250")) == 0) {
+  } else if (strncasecmp(prefix, "z250", 4) == 0) {
     return Image::ImageType::zip250;
-  } else if (strncasecmp(prefix, "remv", sizeof("remv")) == 0) {
+  } else if (strncasecmp(prefix, "remv", 4) == 0) {
     return Image::ImageType::removable;
-  } else if (strncasecmp(prefix, "hddr", sizeof("hddr")) == 0) {
+  } else if (strncasecmp(prefix, "hddr", 4) == 0) {
     return Image::ImageType::harddrive;
   } else {
     return Image::ImageType::unknown;
   }
+}
+
+Image::ImageType Image::InferImageTypeFromExtension(const char * filename)
+{
+  auto len = strnlen(filename, MAX_FILE_PATH);
+  if (len > 3) {
+      // Check the suffix to see if this is a cd-rom image type extension.
+      if (strncasecmp(filename + len - 4, ".iso", sizeof(".iso")) == 0) {
+        return Image::ImageType::cdrom;
+      }
+  }
+  return Image::ImageType::unknown;
 }
 
 Image::ImageType Image::InferImageTypeFromFileName(const char *filename) {
@@ -206,19 +218,13 @@ Image::ImageType Image::InferImageTypeFromFileName(const char *filename) {
   auto len = strnlen(filename, MAX_FILE_PATH);
 
   if (len > 3) {
-    // Check the suffix to see if this is a cd-rom image type extension.
-    if (strncasecmp(filename + len - 4, ".iso", sizeof(".iso")) == 0) {
-      returnValue = Image::ImageType::cdrom;
-    } else {
-      // Check  prefix to see if this uses the ZuluIDE file-prefix format.
-      char *prefix = (char *)calloc(4, sizeof(char));
-      if (prefix) {
-        strncpy(prefix, filename, 4);
-        returnValue = Image::InferImageTypeFromImagePrefix(prefix);
-      }
+    // Check  prefix to see if this uses the ZuluIDE file-prefix format.
+    returnValue = Image::InferImageTypeFromImagePrefix(filename);
+
+    if (returnValue == ImageType::unknown) {
+      returnValue = InferImageTypeFromExtension(filename);
     }
   }
-
   return returnValue;
 }
 

--- a/lib/ZuluControl/src/images/image_iterator.cpp
+++ b/lib/ZuluControl/src/images/image_iterator.cpp
@@ -178,6 +178,7 @@ bool ImageIterator::MoveFirst()
     } else {
       candidateSizeInBytes = currentFile.fileSize();
     }
+    candidateImageType = Image::InferImageTypeFromFileName(candidate);
     curIdx = currentFile.dirIndex();
     currentIsLast = (lastIdx == firstIdx);
     currentIsFirst = true;
@@ -201,7 +202,7 @@ bool ImageIterator::MoveLast()
     } else {
       candidateSizeInBytes = currentFile.fileSize();
     }
-    
+    candidateImageType = Image::InferImageTypeFromFileName(candidate);
     curIdx = currentFile.dirIndex();
     currentIsLast = lastIdx;
     currentIsFirst = (lastIdx == firstIdx);
@@ -224,7 +225,7 @@ bool ImageIterator::MoveToFile(const char *filename)
     } else {
       candidateSizeInBytes = currentFile.fileSize();
     }
-    
+    candidateImageType = Image::InferImageTypeFromFileName(candidate);
     curIdx = currentFile.dirIndex();
     currentIsLast = (curIdx == lastIdx);
     currentIsFirst = (curIdx == firstIdx);
@@ -395,8 +396,8 @@ bool ImageIterator::is_valid_filename(const char *name, bool warning)
 
       for (int i = 0; ignore_exts[i]; i++) {
         if (strcasecmp(extension, ignore_exts[i]) == 0) {
-          // ignore these without log message
-          if (warning) logmsg("-- Ignoring \"", name, "\", file extension ",ignore_exts[i]," is in the reject list");
+          // don't warn about cue files (i == 0)
+          if (warning && i != 0) logmsg("-- Ignoring \"", name, "\", file extension ",ignore_exts[i]," is in the reject list");
           return false;
         }
       }

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -416,28 +416,47 @@ void init_logfile()
     first_open_after_boot = false;
 }
 
+/**
+ * Prefixes (hddr, zipd, etc) take priority over inferring (.iso extension) and normal files
+ */
 drive_type_t searchForDriveType() {
+  Image::ImageType matching_type = Image::ImageType::unknown;
+  Image::ImageType image_type =  Image::ImageType::unknown;
   zuluide::images::ImageIterator imgIter;
   imgIter.Reset();
   while (imgIter.MoveNext()) {
     Image image = imgIter.Get();
+    const char *filename = image.GetFilename().c_str();
 
-    if (image.GetImageType() == Image::ImageType::cdrom) {
-      return DRIVE_TYPE_CDROM;
+    if (strnlen(filename, MAX_FILE_PATH) >= 4) {
+      // Check prefix to see if this uses the ZuluIDE file-prefix format.
+      image_type = Image::InferImageTypeFromImagePrefix(filename);
+      if ( image_type != Image::ImageType::unknown)
+      {
+        g_ide_imagefile.set_prefix(Image::GetImagePrefix(image_type));
+        matching_type = image_type;
+        break;
+      }
     }
 
-    auto imageType = Image::InferImageTypeFromFileName(image.GetFilename().c_str());
-    if (imageType != Image::ImageType::unknown) {
-      imgIter.Cleanup();
-      g_ide_imagefile.set_prefix(Image::GetImagePrefix(imageType));
-      return Image::ToDriveType(imageType);
+    if (image.GetImageType() == Image::ImageType::cdrom) {
+      matching_type = Image::ImageType::cdrom;
+    }
+
+    image_type = Image::InferImageTypeFromExtension(filename);
+    if (image_type != Image::ImageType::unknown) {
+      matching_type = image_type;
     }
   }
 
   imgIter.Cleanup();
 
   // If nothing is found, default to a CDROM.
-  return DRIVE_TYPE_CDROM;
+  if (matching_type == Image::ImageType::unknown) {
+    matching_type = Image::ImageType::cdrom;
+  }
+
+  return Image::ToDriveType(matching_type);
 }
 
 /***
@@ -586,6 +605,8 @@ void loadFirstImage() {
   bool quiet = ini_getbool("IDE", "quiet_image_parsing", 0, CONFIGFILE);
   if (!quiet) logmsg("Parsing images on the SD card");
   zuluide::images::ImageIterator imgIterator;
+  bool matching_type = false;
+  bool found_file = false;
   bool success = false;
   if (ini_getbool("IDE", "init_with_last_used_image", 1, CONFIGFILE))
   {
@@ -616,16 +637,55 @@ void loadFirstImage() {
 
       if (last_filename_valid && imgIterator.MoveToFile(last_used_filename))
       {
-        if (!quiet) logmsg("-- Loading last used image: \"", last_used_filename, "\"");
-        g_StatusController.LoadImage(imgIterator.Get());
-        g_previous_controller_status = g_StatusController.GetStatus();
-        g_loadedFirstImage = true;
-        load_image(imgIterator.Get(), false);
-        success = true;
+        found_file = true;
+        Image::ImageType image_type = imgIterator.Get().GetImageType();
+        // Match media image type with drive type
+        switch (image_type)
+        {
+          case Image::ImageType::unknown:
+            // unknown treat as CD-ROM media
+            [[fallthrough]];
+          case Image::ImageType::cdrom:
+            matching_type = g_ide_device == &g_ide_cdrom;
+            break;
+          case Image::ImageType::harddrive:
+            matching_type = g_ide_device == &g_ide_rigid;
+            break;
+          case Image::ImageType::removable:
+            matching_type = g_ide_device == &g_ide_removable;
+            break;
+          case Image::ImageType::zip100:
+            [[fallthrough]];
+          case Image::ImageType::zip250:
+            [[fallthrough]];
+          case Image::ImageType::zip750:
+            matching_type = g_ide_device == &g_ide_zipdrive;
+            break;
+          // Leave off default so we get a warning for unhandled cases
+        }
+
+        if (matching_type)
+        {
+          if (!quiet) logmsg("-- Loading last used image: \"", last_used_filename, "\"");
+
+          g_StatusController.LoadImage(imgIterator.Get());
+          g_previous_controller_status = g_StatusController.GetStatus();
+          g_loadedFirstImage = true;
+          load_image(imgIterator.Get(), false);
+          success = true;
+        }
       }
-      if (!success)
+
+      if (!success && !quiet)
       {
-        if (!quiet && last_filename_valid) logmsg("-- Last used image \"", last_used_filename, "\" not found");
+        if (found_file && !matching_type)
+        {
+          logmsg("-- Last used image \"", last_used_filename, "\" incorrect media type");
+        }
+        else
+        {
+            logmsg("-- Last used image \"", last_used_filename, "\" not found");
+        }
       }
     }
     quiet = true;
@@ -635,15 +695,31 @@ void loadFirstImage() {
   {
 
     imgIterator.Reset(!quiet);
-    if (!imgIterator.IsEmpty() && imgIterator.MoveNext()) {
-      logmsg("Loading first image ", imgIterator.Get().GetFilename().c_str());
-      g_StatusController.LoadImage(imgIterator.Get());
-      g_previous_controller_status = g_StatusController.GetStatus();
-      g_loadedFirstImage = true;
-      load_image(imgIterator.Get(), false);
-    } else {
-      logmsg("No valid image files found");
-      blinkStatus(BLINK_ERROR_NO_IMAGES);
+    const char *prefix = g_ide_imagefile.get_prefix();
+    if (!imgIterator.IsEmpty())
+    {
+      while(imgIterator.MoveNext())
+      {
+        // If a prefix is used to define the drive type, only load prefix images for the first image
+        if (prefix[0] != '\0'
+          && imgIterator.Get().GetImageType() != Image::InferImageTypeFromImagePrefix(prefix)
+        )
+        {
+          continue;
+        }
+        logmsg("Loading first image ", imgIterator.Get().GetFilename().c_str());
+        g_StatusController.LoadImage(imgIterator.Get());
+        g_previous_controller_status = g_StatusController.GetStatus();
+        g_loadedFirstImage = true;
+        load_image(imgIterator.Get(), false);
+        break;
+      }
+
+      if (!g_loadedFirstImage)
+      {
+        logmsg("No valid image files found");
+        blinkStatus(BLINK_ERROR_NO_IMAGES);
+      }
     }
   }
 

--- a/src/ide_imagefile.cpp
+++ b/src/ide_imagefile.cpp
@@ -226,10 +226,11 @@ drive_type_t IDEImageFile::get_drive_type()
 
 void IDEImageFile::set_prefix(const char *prefix)
 {
-    strcpy(m_prefix, prefix);
+    strncpy(m_prefix, prefix, 4);
+    m_prefix[4] = '\0';
 }
 
-const char* const IDEImageFile::get_prefix()
+const char *const IDEImageFile::get_prefix()
 {
     return m_prefix;
 }


### PR DESCRIPTION
If an image file with a device type prefix (`HDDR`, `CDRM`, `ZIPD`, `REMV`) is present in the root directory, _always_ set the device type using the specified prefix. This overrides any other filenames in the root directory.

For example, if there were a A-CDROM.iso and a ZIPD-Zip-disk.img in the root directory, set the drive type to zip disk. The previous behavior would have configured the ZuluIDE device type as a CD-ROM drive, because the first letter 'A' is alphabetically before 'Z'.

If the previous/last image was saved in zululast.txt and still exists on the SD card, but a prefixed media has been added to the SD card, the ZuluIDE will now invalidate the image in zululast.txt because it is no longer compatible with the drive type.