### PR TITLE
ZuluIDE V2: Improve sniffer functionality

### DIFF
--- a/lib/ZuluIDE_platform_RP2350/rp2350_sniffer.cpp
+++ b/lib/ZuluIDE_platform_RP2350/rp2350_sniffer.cpp
@@ -31,7 +31,9 @@
 #include <hardware/gpio.h>
 #include <hardware/dma.h>
 #include <SdFat.h>
+#include <minIni.h>
 #include "ZuluIDE.h"
+#include "ZuluIDE_config.h"
 #include "rp2350_sniffer.pio.h"
 
 /* These settings can be overridden in platformio.ini */
@@ -61,9 +63,18 @@
 #define SNIFFER_PIO pio2
 #endif
 
-// PIO state machine used
+// PIO state machine used for main sniffer code
 #ifndef SNIFFER_PIO_SM
 #define SNIFFER_PIO_SM 3
+#endif
+
+// PIO state machines for triggering
+#ifndef SNIFFER_PIO_SM_TRIGGER_MIN
+#define SNIFFER_PIO_SM_TRIGGER_MIN 0
+#endif
+
+#ifndef SNIFFER_PIO_SM_TRIGGER_MAX
+#define SNIFFER_PIO_SM_TRIGGER_MAX 2
 #endif
 
 // Millisecond interval to report data and to sync to SD card
@@ -83,6 +94,7 @@ bool g_rp2350_passive_sniffer;
 static struct {
     bool channels_claimed;
     uint32_t offset_sniffer;
+    uint32_t offset_trigger;
     FsFile file;
     uint32_t sync_time;
 
@@ -94,6 +106,9 @@ static struct {
 
     uint32_t total_bytes;
     uint32_t overruns;
+
+    // Last log position written
+    uint32_t logpos;
 
     // Number of blocks written, used by sd write callback
     uint32_t sd_blocks_complete;
@@ -107,6 +122,120 @@ static struct {
 __attribute__((aligned(sizeof(uint32_t*) * DMA_BLOCKPTR_COUNT)))
 uint32_t *g_sniffer_dma_dest_blocks[DMA_BLOCKPTR_COUNT];
 
+// Sniffer has 27 inputs, lowest is DIOW and highest IORDY
+#define SNIFFER_PINCOUNT 27
+#define SNIFFER_PINS_ALL ((~(uint32_t)0) >> (32 - SNIFFER_PINCOUNT))
+
+// Default trigger set: DIOW, DIOR, CS0, CS1, DMACK, D0-D15, DATA_SEL, DATA_DIR, IORDY
+#define SNIFFER_DEFAULT_TRIGPINS 0x07FFFFE3
+
+// Setup trigger state machines based on pin mask.
+// Up to three contiguous pin ranges are supported.
+void rp2350_sniffer_setup_triggers(uint32_t trigpins)
+{
+    trigpins &= SNIFFER_PINS_ALL;
+    logmsg("Sniffer trigger configuration: ", trigpins);
+
+    // Find continuous pin ranges and configure state machines
+    for (int sm = SNIFFER_PIO_SM_TRIGGER_MIN; sm <= SNIFFER_PIO_SM_TRIGGER_MAX; sm++)
+    {
+        if (!trigpins) break; // No more pins
+
+        int lowpin = -1;
+        for (int i = 0; i < SNIFFER_PINCOUNT; i++)
+        {
+            if (trigpins & (1 << i))
+            {
+                lowpin = i;
+                break;
+            }
+        }
+
+        int highpin = lowpin;
+        for (int i = lowpin; i < SNIFFER_PINCOUNT; i++)
+        {
+            if (!(trigpins & (1 << i)))
+            {
+                break;
+            }
+            else
+            {
+                // Clear the pins are part of this range
+                highpin = i;
+                trigpins &= ~(1 << i);
+            }
+        }
+
+        logmsg("Sniffer SM", sm, " triggers on pin range ", lowpin, " - ", highpin);
+
+        pio_sm_config cfg = rp2350_sniffer_trigger_program_get_default_config(g_sniffer.offset_trigger);
+        sm_config_set_in_pins(&cfg, IDE_DIOW + lowpin);
+        sm_config_set_in_pin_count(&cfg, highpin - lowpin + 1);
+        pio_sm_init(SNIFFER_PIO, sm, g_sniffer.offset_trigger, &cfg);
+        pio_sm_set_enabled(SNIFFER_PIO, sm, true);
+    }
+
+    // Check if we were able to setup all pins
+    if (trigpins)
+    {
+        logmsg("Sniffer trigger has too many pin ranges, remaining pins ignored: ", trigpins);
+    }
+}
+
+// Write any new log data to sniffer output file
+void rp2350_sniffer_write_logblock(bool first_block = false)
+{
+    if (first_block || log_get_buffer_len() > g_sniffer.logpos)
+    {
+        uint32_t tmpbuf[512 / sizeof(uint32_t)]; // Write in full SD card sectors
+        int wrpos = 0;
+
+        if (first_block)
+        {
+            // Identify sniffer format version and CPU frequency in first word of file
+            uint8_t MHz = clock_get_hz(clk_sys) / 1000000;
+            tmpbuf[0] = 0xFF000000 | (MHz << 8) | 2;
+
+            // Set system timestamp at start of file
+            tmpbuf[1] = 0xFC000000 | (millis() & 0xFFFFFF);
+
+            wrpos = 2;
+        }
+
+        // Set the log data length to the remaining length of
+        // the block. Unused bytes are set to 0x00.
+        wrpos += 1;
+        uint32_t logmaxlen = sizeof(tmpbuf) - wrpos * sizeof(uint32_t);
+        tmpbuf[wrpos - 1] = 0xFF010000 | logmaxlen;
+
+        // Check how much log data is available
+        uint32_t available = 0;
+        const char *log = log_get_buffer(&g_sniffer.logpos, &available);
+        if (available > logmaxlen)
+        {
+            // Write only as much log data as fits in one SD card sector
+            g_sniffer.logpos -= available - logmaxlen;
+            available = logmaxlen;
+        }
+
+        memcpy(&tmpbuf[wrpos], log, available);
+
+        if (available < logmaxlen)
+        {
+            // Zero out rest of the bytes in the block
+            memset((char*)&tmpbuf[wrpos] + available, 0, logmaxlen - available);
+        }
+
+        if (g_sniffer.file.write(tmpbuf, sizeof(tmpbuf)) != sizeof(tmpbuf))
+        {
+            logmsg("Sniffer write failed");
+            g_sniffer.file.close();
+        }
+
+        g_sniffer.total_bytes += sizeof(tmpbuf);
+    }
+}
+
 bool rp2350_sniffer_init(const char *filename, bool passive)
 {
     g_rp2350_passive_sniffer = passive;
@@ -114,13 +243,28 @@ bool rp2350_sniffer_init(const char *filename, bool passive)
     if (!g_sniffer.channels_claimed)
     {
         pio_sm_claim(SNIFFER_PIO, SNIFFER_PIO_SM);
+
+        for (int i = SNIFFER_PIO_SM_TRIGGER_MIN; i <= SNIFFER_PIO_SM_TRIGGER_MAX; i++)
+        {
+            pio_sm_claim(SNIFFER_PIO, i);
+        }
+
+        pio_clear_instruction_memory(SNIFFER_PIO);
+        g_sniffer.offset_sniffer = pio_add_program(SNIFFER_PIO, &rp2350_sniffer_program);
+        g_sniffer.offset_trigger = pio_add_program(SNIFFER_PIO, &rp2350_sniffer_trigger_program);
+
         dma_channel_claim(SNIFFER_DMACH);
         dma_channel_claim(SNIFFER_DMACH_B);
-        g_sniffer.offset_sniffer = pio_add_program(SNIFFER_PIO, &rp2350_sniffer_program);
         g_sniffer.channels_claimed = true;
     }
 
     pio_sm_set_enabled(SNIFFER_PIO, SNIFFER_PIO_SM, false);
+
+    for (int i = SNIFFER_PIO_SM_TRIGGER_MIN; i <= SNIFFER_PIO_SM_TRIGGER_MAX; i++)
+    {
+        pio_sm_set_enabled(SNIFFER_PIO, i, false);
+    }
+
     dma_channel_abort(SNIFFER_DMACH);
     g_sniffer.file.close();
     g_sniffer.total_blocks = 0;
@@ -130,6 +274,7 @@ bool rp2350_sniffer_init(const char *filename, bool passive)
     g_sniffer.total_blocks = 0;
     g_sniffer.sd_blocks_complete = 0;
     g_sniffer.sync_time = 0;
+    g_sniffer.logpos = 0;
 
     g_sniffer.file = SD.open(filename, O_WRONLY | O_CREAT | O_TRUNC);
     if (!g_sniffer.file.isOpen())
@@ -138,11 +283,18 @@ bool rp2350_sniffer_init(const char *filename, bool passive)
         return false;
     }
 
+    // Write version and beginning of the log
+    rp2350_sniffer_write_logblock(true);
+
     {
         pio_sm_config cfg = rp2350_sniffer_program_get_default_config(g_sniffer.offset_sniffer);
         sm_config_set_in_pins(&cfg, IDE_DIOW);
-        pio_sm_init(SNIFFER_PIO, SNIFFER_PIO_SM, g_sniffer.offset_sniffer, &cfg);
+        sm_config_set_mov_status(&cfg, STATUS_IRQ_SET, SNIFFER_TRIGGER_IRQ);
+        pio_sm_init(SNIFFER_PIO, SNIFFER_PIO_SM, g_sniffer.offset_sniffer + rp2350_sniffer_offset_init, &cfg);
     }
+
+    uint32_t trigpins = ini_getl("IDE", "sniffer_trigpins", SNIFFER_DEFAULT_TRIGPINS, CONFIGFILE);
+    rp2350_sniffer_setup_triggers(trigpins);
 
     // First DMA channel for data transfer
     {
@@ -181,9 +333,6 @@ bool rp2350_sniffer_init(const char *filename, bool passive)
     }
 
     // Start encoding with the initial states of the pins
-    pio_sm_exec(SNIFFER_PIO, SNIFFER_PIO_SM, pio_encode_set(pio_osr, 30));
-    pio_sm_exec(SNIFFER_PIO, SNIFFER_PIO_SM, pio_encode_mov(pio_x, pio_pins));
-    pio_sm_exec(SNIFFER_PIO, SNIFFER_PIO_SM, pio_encode_jmp(g_sniffer.offset_sniffer + rp2350_sniffer_offset_change));
     pio_sm_set_enabled(SNIFFER_PIO, SNIFFER_PIO_SM, true);
 
     return true;
@@ -266,8 +415,15 @@ void rp2350_sniffer_poll()
             g_sniffer.sd_blocks_complete = 0;
             size_t to_write = available * SNIFFER_BLOCKSIZE;
             platform_set_sd_callback(sniffer_sd_callback, readptr);
-            g_sniffer.file.write(readptr, to_write);
+            size_t wrote = g_sniffer.file.write(readptr, to_write);
             platform_set_sd_callback(nullptr, nullptr);
+
+            if (wrote != to_write)
+            {
+                logmsg("Sniffer write failed");
+                g_sniffer.file.close();
+                break;
+            }
 
             // Finish the write operation and release blocks to DMA
             sniffer_sd_callback(to_write);
@@ -284,6 +440,9 @@ void rp2350_sniffer_poll()
         // Synchronize file size
         if (g_sniffer.should_sync)
         {
+            // Write any log data
+            rp2350_sniffer_write_logblock();
+
             if (g_sniffer.writes_since_sync == 0)
             {
                 // Write the partially finished block and seek backwards so it will be rewritten once full.
@@ -303,6 +462,13 @@ void rp2350_sniffer_poll()
             g_sniffer.writes_since_sync = 0;
             g_sniffer.sync_time = millis();
         }
+    }
+
+    if (g_sniffer.writes_since_sync > 0)
+    {
+        // Only write log data if there has been sniffer data written.
+        // Otherwise it ends up overwriting the partial block.
+        rp2350_sniffer_write_logblock();
     }
 
     if (!g_sniffer.should_sync && (uint32_t)(millis() - g_sniffer.sync_time) > SNIFFER_SYNC_INTERVAL)

--- a/lib/ZuluIDE_platform_RP2350/rp2350_sniffer.pio
+++ b/lib/ZuluIDE_platform_RP2350/rp2350_sniffer.pio
@@ -38,19 +38,21 @@
  *    Bits 26..0:  P (Pin states or long time delta)
  *
  * If D != 31, then P is the new state of the 27 IO pins.
- * Clock cycles since previous sample is 5 * (31 - D)
+ * Clock cycles since previous sample is 3 * (33 - D)
  *
  * If D == 31 and P <= 0x03FFFFFF, then P is a long time delta.
- * Pin states have not changed and clock cycles is 5 * (0x03FFFFFF - P + 3)
+ * Pin states have not changed and clock cycles is 3 * (0x03FFFFFF - P - 1)
  *
- * If D == 31 and 0x03FFFFFF < P <= 0x07FFFFFE, these are used for system timestamp
- * reporting by CPU.
+ * If D == 31 and 0x03FFFFFF < P <= 0x07FFFFFE, these are used by CPU as follows:
+ *     - 0xFCtttttt  indicates system timestamp
+ *     - 0xFF00ffnn  indicates sniffer format version and CPU frequency (MHz)
+ *     - 0xFF01nnnn  n bytes of system log data follows
  *
  * If D == 31 and P == 0x07FFFFFF (whole word is all ones), then maximum time delta
- * has passed. Clock cycles is 5 * (0x03FFFFFF + 3) (approx 2.2 seconds @ 150 MHz)
- *
+ * has passed. Clock cycles is 3 * (0x03FFFFFF + 3) (approx 1 second @ 200 MHz)
  */
 
+.define PUBLIC SNIFFER_TRIGGER_IRQ 0
 .program rp2350_sniffer
 .pio_version 1
 .fifo rx
@@ -60,20 +62,20 @@
 lg_change:
     mov y, ~null     ; Set Y to all ones
     in y, 5          ; Load the top 5 bits to value 31 to indicate long time delta
-    in osr, 27       ; Load the 27 bit time delta and autopush
-    mov osr, null    ; Set time delta to 0 for the pin state push below
+    in x, 27         ; Load the 27 bit time delta and autopush
 
-PUBLIC change:
-    in osr, 5        ; Load 5-bit time delta (value 0..30)
-    in x, 27         ; Load pin states and autopush
-    mov y, x         ; Set the next pin states to compare against
+PUBLIC init:
+    mov x, null      ; Set time delta for the pin state push below
+
+change:
+    in x, 5          ; Load 5-bit time delta (value 0..30)
+    in pins, 27      ; Load pin states and autopush
+    irq clear SNIFFER_TRIGGER_IRQ
     set x, 30        ; Initialize next time delta counter
 
 loop:
-    mov osr, x       ; Keep time delta counter in osr temporarily
-    mov x, pins      ; Load pin states for comparison
-    jmp x != y, change  ; If pin values have changed, push new state
-    mov x, osr       ; Load time delta counter back
+    mov y, status    ; Check trigger interrupt status
+    jmp y--, change  ; If triggered, push new state
     jmp x--, loop    ; Loop until time delta overflows
 
     ; Time delta exceeded 30 cycles, encode as long gap
@@ -81,16 +83,30 @@ loop:
     .wrap_target
 long_gap:
     mov osr, ~null   ; Set OSR to all ones
-    out null, 6      ; Modify OSR to 0x03FFFFFF
-    mov x, osr       ; Load the new time delta counter to x
+    out x, 26        ; Set X to 0x03FFFFFF
 
 loop_lg:
-    mov osr, x       ; Keep time delta counter in osr temporarily
-    mov x, pins      ; Load pin states for comparison
-    jmp x != y, lg_change  ; If pin values have changed, push new state
-    mov x, osr       ; Load time delta counter back
+    mov y, status    ; Check trigger interrupt status
+    jmp y--, lg_change  ; If triggered, push long timestamp and new state
     jmp x--, loop_lg ; Loop until time delta overflows
 
     ; Timestamp has wrapped, X is now 0xFFFFFFFF
     in x, 32         ; Push the word that indicates long gap at maximum time delta
     .wrap
+
+; Auxiliary state machines that monitor pins for changes to trigger the
+; sniffer. There can be up to three of these trigger machines, and each
+; can handle a continuous range of 1-27 trigger pins.
+
+.program rp2350_sniffer_trigger
+.pio_version 1
+
+change:
+    irq set SNIFFER_TRIGGER_IRQ     ; Trigger sniffer to store the pin states
+    mov y, x            ; Update Y for comparing
+
+.wrap_target
+wait_change:
+    mov x, pins         ; Read new pin states
+    jmp x != y, change  ; Detect change
+.wrap

--- a/lib/ZuluIDE_platform_RP2350/rp2350_sniffer.pio.h
+++ b/lib/ZuluIDE_platform_RP2350/rp2350_sniffer.pio.h
@@ -8,47 +8,44 @@
 #include "hardware/pio.h"
 #endif
 
+#define SNIFFER_TRIGGER_IRQ 0
+
 // -------------- //
 // rp2350_sniffer //
 // -------------- //
 
-#define rp2350_sniffer_wrap_target 13
-#define rp2350_sniffer_wrap 21
+#define rp2350_sniffer_wrap_target 11
+#define rp2350_sniffer_wrap 16
 #define rp2350_sniffer_pio_version 1
 
-#define rp2350_sniffer_offset_change 4u
+#define rp2350_sniffer_offset_init 3u
 
 static const uint16_t rp2350_sniffer_program_instructions[] = {
     0xa04b, //  0: mov    y, !null
     0x4045, //  1: in     y, 5
-    0x40fb, //  2: in     osr, 27
-    0xa0e3, //  3: mov    osr, null
-    0x40e5, //  4: in     osr, 5
-    0x403b, //  5: in     x, 27
-    0xa041, //  6: mov    y, x
+    0x403b, //  2: in     x, 27
+    0xa023, //  3: mov    x, null
+    0x4025, //  4: in     x, 5
+    0x401b, //  5: in     pins, 27
+    0xc040, //  6: irq    clear 0
     0xe03e, //  7: set    x, 30
-    0xa0e1, //  8: mov    osr, x
-    0xa020, //  9: mov    x, pins
-    0x00a4, // 10: jmp    x != y, 4
-    0xa027, // 11: mov    x, osr
-    0x0048, // 12: jmp    x--, 8
+    0xa045, //  8: mov    y, status
+    0x0084, //  9: jmp    y--, 4
+    0x0048, // 10: jmp    x--, 8
             //     .wrap_target
-    0xa0eb, // 13: mov    osr, !null
-    0x6066, // 14: out    null, 6
-    0xa027, // 15: mov    x, osr
-    0xa0e1, // 16: mov    osr, x
-    0xa020, // 17: mov    x, pins
-    0x00a0, // 18: jmp    x != y, 0
-    0xa027, // 19: mov    x, osr
-    0x0050, // 20: jmp    x--, 16
-    0x4020, // 21: in     x, 32
+    0xa0eb, // 11: mov    osr, !null
+    0x603a, // 12: out    x, 26
+    0xa045, // 13: mov    y, status
+    0x0080, // 14: jmp    y--, 0
+    0x004d, // 15: jmp    x--, 13
+    0x4020, // 16: in     x, 32
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program rp2350_sniffer_program = {
     .instructions = rp2350_sniffer_program_instructions,
-    .length = 22,
+    .length = 17,
     .origin = -1,
     .pio_version = rp2350_sniffer_pio_version,
 #if PICO_PIO_VERSION > 0
@@ -64,6 +61,41 @@ static inline pio_sm_config rp2350_sniffer_program_get_default_config(uint offse
     sm_config_set_out_pin_count(&c, 0);
     sm_config_set_out_shift(&c, 1, 0, 32);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_RX);
+    return c;
+}
+#endif
+
+// ---------------------- //
+// rp2350_sniffer_trigger //
+// ---------------------- //
+
+#define rp2350_sniffer_trigger_wrap_target 2
+#define rp2350_sniffer_trigger_wrap 3
+#define rp2350_sniffer_trigger_pio_version 1
+
+static const uint16_t rp2350_sniffer_trigger_program_instructions[] = {
+    0xc000, //  0: irq    nowait 0
+    0xa041, //  1: mov    y, x
+            //     .wrap_target
+    0xa020, //  2: mov    x, pins
+    0x00a0, //  3: jmp    x != y, 0
+            //     .wrap
+};
+
+#if !PICO_NO_HARDWARE
+static const struct pio_program rp2350_sniffer_trigger_program = {
+    .instructions = rp2350_sniffer_trigger_program_instructions,
+    .length = 4,
+    .origin = -1,
+    .pio_version = rp2350_sniffer_trigger_pio_version,
+#if PICO_PIO_VERSION > 0
+    .used_gpio_ranges = 0x0
+#endif
+};
+
+static inline pio_sm_config rp2350_sniffer_trigger_program_get_default_config(uint offset) {
+    pio_sm_config c = pio_get_default_sm_config();
+    sm_config_set_wrap(&c, offset + rp2350_sniffer_trigger_wrap_target, offset + rp2350_sniffer_trigger_wrap);
     return c;
 }
 #endif

--- a/utils/decode_sniff_data_rp2350.py
+++ b/utils/decode_sniff_data_rp2350.py
@@ -78,9 +78,9 @@ class SniffDecoder:
          (26, 1, 'IORDY', 'i')
     )
 
-    cpu_freq = 150e6      # CPU frequency for timestamps
+    cpu_freq = 200e6      # CPU frequency for timestamps
     divider = 5           # Divider used for VCD timestamps
-    timescale = '33333ps' # VCD timescale (divider / cpu_freq)
+    timescale = '25ns' # VCD timescale (divider / cpu_freq)
 
     def __init__(self):
         self.reset()
@@ -92,6 +92,8 @@ class SniffDecoder:
         self.systime_ref = 0
         self.last_vcd_timestamp = 0
         self.pin_states = 0
+        self.version = 1
+        self.logtxt = b''
 
     def get_systime(self):
         '''Interpolate system time from sample timestamps.'''
@@ -103,24 +105,53 @@ class SniffDecoder:
         '''
 
         result = []
+        logdatalen = 0
+
         for word, in struct.iter_unpack("<I", data):
             d = word >> 27
             p = word & 0x07FFFFFF
             max_timedelta = 0x03FFFFFF
 
-            if d != 31:
-                self.timestamp += 5 * (31 - d)
-                self.pin_states = p
-            elif p <= max_timedelta:
-                self.timestamp += 5 * (max_timedelta - p + 3)
+            if logdatalen > 0:
+                self.logtxt += struct.pack("<I", word).replace(b'\x00', b'')
+                logdatalen -= 4
             elif (word >> 24) == 0xFC:
                 # System millisecond timestamp for correlating with logs
                 self.systime = word & 0xFFFFFF
                 self.systime_ref = self.timestamp
-            elif word == 0xFFFFFFFF:
-                self.timestamp += 5 * (max_timedelta + 3)
+            elif (word >> 16) == 0xFF00:
+                self.version = word & 0xFF
+                self.cpu_freq = ((word >> 8) & 0xFF) * 1e6
 
-            result.append((self.timestamp, self.pin_states, self.get_systime()))
+                print("Sniffer version %d, CPU frequency %d MHz" % (self.version, self.cpu_freq // 1e6))
+
+                if self.version >= 2:
+                    self.divider = 3
+
+                self.timescale = '%dps' % (1e12 * self.divider / self.cpu_freq)
+
+            elif (word >> 16) == 0xFF01:
+                logdatalen = (word & 0xFFFF)
+                assert logdatalen % 4 == 0
+            else:
+                if self.version >= 2:
+                    if d != 31:
+                        self.timestamp += 3 * (33 - d)
+                        self.pin_states = p
+                    elif p <= max_timedelta:
+                        self.timestamp += 3 * (max_timedelta - p - 1)
+                    elif word == 0xFFFFFFFF:
+                        self.timestamp += 3 * (max_timedelta + 3)
+                else:
+                    if d != 31:
+                        self.timestamp += 5 * (31 - d)
+                        self.pin_states = p
+                    elif p <= max_timedelta:
+                        self.timestamp += 5 * (max_timedelta - p + 3)
+                    elif word == 0xFFFFFFFF:
+                        self.timestamp += 5 * (max_timedelta + 3)
+
+                result.append((self.timestamp, self.pin_states, self.get_systime()))
 
         return result
 
@@ -162,14 +193,18 @@ class SniffDecoder:
         '''
         self.reset()
 
-        outfile.write('\n'.join(self.format_vcd_header()) + '\n\n')
-
         tcount = 0
         while True:
             data = infile.read(blocksize)
             if not data: break
 
             trans = self.decode(data)
+
+            if len(trans) and tcount == 0:
+                # Write header after we have decoded the first block, which
+                # includes format version information.
+                outfile.write('\n'.join(self.format_vcd_header()) + '\n\n')
+
             lines = self.format_vcd(trans)
             outfile.write('\n'.join(lines) + '\n')
 
@@ -183,6 +218,7 @@ if __name__ == '__main__':
 
     infilename = sys.argv[1]
     outfilename = os.path.splitext(infilename)[0] + os.path.extsep + 'vcd'
+    logfilename = os.path.splitext(infilename)[0] + os.path.extsep + 'txt'
 
     print("Writing to %s" % outfilename)
 
@@ -197,6 +233,10 @@ if __name__ == '__main__':
 
     print("Done, total %d transitions, length %0.1f s,                        " %
           (tcount, decoder.last_vcd_timestamp * decoder.divider / decoder.cpu_freq))
+
+    if decoder.logtxt:
+        open(logfilename, 'wb').write(decoder.logtxt)
+        print("Saved %d bytes of log text to %s" % (len(decoder.logtxt), logfilename))
 
     if decoder.last_vcd_timestamp > 1e9:
         print("WARNING: Result file has a large time range, PulseView may take a lot of memory when loading")

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -71,3 +71,4 @@
 # sniffer = 0     # Disable sniffer (default)
 # sniffer = 1     # Enable IDE bus sniffer in active mode, ZuluIDE monitors its own communication
 # sniffer = 2     # Enable IDE bus sniffer in passive mode, ZuluIDE monitors other devices but doesn't communicate
+# sniffer_trigpins = 0x07FFFFE3  # Adjust which IO pins the sniffer triggers on, by default all except DA0-DA2


### PR DESCRIPTION
Sniffer now ignores DA0-DA2 transitions by default. These signals are sometimes connected to system address bus on old machines, which caused excessive traffic. All signals are still stored when one of the enabled trigger signal changes.

Improved timestamp accuracy to +- 15 ns (was +- 25 ns).

System log messages are now included in sniff.dat.