### PR TITLE
Add mandatory ATA command Flush Cache

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -103,6 +103,7 @@ bool IDEATAPIDevice::handle_command(ide_registers_t *regs)
         case IDE_CMD_IDENTIFY_PACKET_DEVICE: return cmd_identify_packet_device(regs);
         case IDE_CMD_PACKET: return cmd_packet(regs);
         case IDE_CMD_DEVICE_RESET: return cmd_device_reset(regs);
+        case IDE_CMD_FLUSH_CACHE: return cmd_flush_cache(regs);
         case IDE_CMD_IDLE_IMMEDIATE_95H: [[fallthrough]];
         case IDE_CMD_IDLE_IMMEDIATE_E1H: [[fallthrough]];
         case IDE_CMD_IDLE_97H:           [[fallthrough]];
@@ -405,6 +406,15 @@ bool IDEATAPIDevice::cmd_device_reset(ide_registers_t *regs)
     fill_device_signature(regs);
     regs->status &= IDE_STATUS_IDX; // clear bits BSY, 6,5,4,2,0
     ide_phy_set_regs(regs);
+    return true;
+}
+
+bool IDEATAPIDevice::cmd_flush_cache(ide_registers_t *regs)
+{
+    /// stub out flush cache command, just return success
+    regs->error = 0;
+    ide_phy_set_regs(regs);
+    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
     return true;
 }
 

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -172,6 +172,7 @@ protected:
     virtual bool cmd_identify_packet_device(ide_registers_t *regs);
     virtual bool cmd_packet(ide_registers_t *regs);
     virtual bool cmd_device_reset(ide_registers_t *regs);
+    virtual bool cmd_flush_cache(ide_registers_t *regs);
     virtual bool cmd_idle(ide_registers_t *regs);
     virtual bool cmd_check_power_mode(ide_registers_t *regs);
 

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -205,6 +205,7 @@ bool IDERigidDevice::handle_command(ide_registers_t *regs)
         case IDE_CMD_WRITE_SECTORS_WOUT_RETRIES:
         case IDE_CMD_WRITE_SECTORS: return cmd_write(regs, false, false);
         case IDE_CMD_WRITE_MULTIPLE: return cmd_write(regs, false, true);
+        case IDE_CMD_FLUSH_CACHE: return cmd_flush_cache(regs);
         case IDE_CMD_READ_BUFFER: return cmd_read_buffer(regs);
         case IDE_CMD_WRITE_BUFFER: return cmd_write_buffer(regs);
         case IDE_CMD_INIT_DEV_PARAMS: return cmd_init_dev_params(regs);
@@ -527,6 +528,15 @@ bool IDERigidDevice::cmd_write(ide_registers_t *regs, bool dma_transfer, bool is
         ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC | IDE_STATUS_ERR);
     }
     return status;
+}
+
+bool IDERigidDevice::cmd_flush_cache(ide_registers_t *regs)
+{
+    /// stub out flush cache command, just return success
+    regs->error = 0;
+    ide_phy_set_regs(regs);
+    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
+    return true;
 }
 
 bool IDERigidDevice::cmd_read_buffer(ide_registers_t *regs)

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -142,6 +142,7 @@ protected:
     virtual bool cmd_seek(ide_registers_t *regs);
     virtual bool cmd_read(ide_registers_t *regs, bool dma_transfer, bool verify_only, bool is_multiple);
     virtual bool cmd_write(ide_registers_t *regs, bool dma_transfer, bool is_multiple);
+    virtual bool cmd_flush_cache(ide_registers_t *regs);
     virtual bool cmd_read_buffer(ide_registers_t *regs);
     virtual bool cmd_write_buffer(ide_registers_t *regs);
     virtual bool cmd_init_dev_params(ide_registers_t *regs);


### PR DESCRIPTION
This command was called in a Win 98 shutdown. The ATA spec says it is mandatory for all ATA devices so it is now implemented for both ATAPI and rigid IDE devices.

As a side note, it didn't fix the issue of the computer not shutting down properly, but the error message in the ZuluIDE log went away.