### PR TITLE
Always return seek complete when device is ready

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/rp2040_ide_phy.cpp
+++ b/lib/ZuluIDE_platform_RP2040/rp2040_ide_phy.cpp
@@ -390,7 +390,7 @@ void ide_phy_start_read(uint32_t blocklen, int udma_mode)
         // Transfer in PIO mode
         fpga_wrcmd(FPGA_CMD_START_READ, (const uint8_t*)&last_word_idx, 2);
         g_ide_phy.udma_mode = -1;
-        ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DATAREQ);
+        ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC | IDE_STATUS_DATAREQ);
     }
     else
     {

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -188,11 +188,11 @@ bool IDEATAPIDevice::cmd_set_features(ide_registers_t *regs)
     ide_phy_set_regs(regs);
     if (regs->error == 0)
     {
-        ide_phy_assert_irq(IDE_STATUS_DEVRDY);
+        ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
     }
     else
     {
-        ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_ERR);
+        ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC| IDE_STATUS_ERR);
     }
 
     return true;
@@ -325,7 +325,7 @@ bool IDEATAPIDevice::cmd_identify_packet_device(ide_registers_t *regs)
 
     regs->error = 0;
     ide_phy_set_regs(regs);
-    ide_phy_assert_irq(IDE_STATUS_DEVRDY);
+    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
     return true;
 }
 
@@ -465,9 +465,9 @@ bool IDEATAPIDevice::set_device_signature(uint8_t error, bool was_reset)
     {
         // Command complete
         if (error == IDE_ERROR_ABORT)
-            ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_ERR);
+            ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC| IDE_STATUS_ERR);
         else
-            ide_phy_assert_irq(IDE_STATUS_DEVRDY);
+            ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
 
     }
 
@@ -934,7 +934,7 @@ bool IDEATAPIDevice::atapi_cmd_error(uint8_t sense_key, uint16_t sense_asc)
     regs.lba_mid = 0xFE;
     regs.lba_high = 0xFF;
     ide_phy_set_regs(&regs);
-    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_ERR);
+    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC |  IDE_STATUS_ERR);
 
     return true;
 }


### PR DESCRIPTION
Most ATA devices send Device Seek Complete (DSC) in the status register when the status register has the Device Ready (DRDY) bit set.

DSC bit is obsolete in later ATA specs, but since we set it after some ATA commands it should be normalized for all commands. This commit adds DSC to the few commands that are missing it.