### PR TITLE
Fix RP2040 reading WiFi settings on wrong core

### DIFF
--- a/lib/ZuluControl/include/zuluide/i2c/i2c_actions.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_actions.h
@@ -1,0 +1,35 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2026 Rabbit Hole Computing™
+ *
+ * ZuluIDE™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Under Section 7 of GPL version 3, you are granted additional
+ * permissions described in the ZuluIDE Hardware Support Library Exception
+ * (GPL-3.0_HSL_Exception.md), as published by Rabbit Hole Computing™.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+#pragma once
+
+namespace zuluide::i2c {
+
+  class I2CActions
+  { 
+    public:
+    void WiFiConnect();
+  };
+}

--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -33,7 +33,7 @@
 #include "i2c_server_src_type.h"
 #include <string>
 
-#define I2C_API_VERSION "3.2.0"
+#define I2C_API_VERSION "3.2.1"
 
 // Delay between reading the filenames off the SD card in milliseconds
 #ifndef I2C_FILENAME_TRANSFER_DELAY
@@ -189,6 +189,11 @@ namespace zuluide::i2c {
     void HandleFetchImages(const std::unique_ptr<ImageResponse<i2c_server_source_t>>&& response);
     void HandleFetchImage(const std::unique_ptr<ImageResponse<i2c_server_source_t>>&& response);
     void HandleSetToCurrent(const std::unique_ptr<ImageResponse<i2c_server_source_t>>&& response);
+
+    /**
+     * Sends WiFi connection request
+     */
+    void RequestWiFiConnect(const i2c_server_source_t source);
     /**
      * Sends a clean up iterator request
      */

--- a/lib/ZuluControl/include/zuluide/pipe/image_request.h
+++ b/lib/ZuluControl/include/zuluide/pipe/image_request.h
@@ -32,7 +32,7 @@
 
 namespace zuluide::pipe {
   
-enum class image_request_t {First, Next, Prev, Current, Last, Cleanup, Reset, Empty};
+enum class image_request_t {First, Next, Prev, Current, Last, Cleanup, Reset, WiFiConnect, Empty};
 template<typename SrcType>
 class ImageRequest{
   public:

--- a/lib/ZuluControl/include/zuluide/pipe/image_response_pipe.h
+++ b/lib/ZuluControl/include/zuluide/pipe/image_response_pipe.h
@@ -26,10 +26,10 @@
 #include <zuluide/observable.h>
 #include <zuluide/queue/safe_queue.h>
 #include <zuluide/images/image_iterator.h>
+#include <zuluide/i2c/i2c_actions.h>
 #include "zuluide/pipe/image_response_pipe.h"
 #include <ide_protocol.h>
-#include "ZuluIDE_log.h"
-
+#include <ZuluIDE_log.h>
 #include <algorithm>
 #include <functional>
 #include <memory>
@@ -77,6 +77,11 @@ class ImageResponsePipe : public Observable<ImageResponse<SrcType>>
      * Image iterator
      */
     zuluide::images::ImageIterator imageIterator;
+
+    /***
+     * I2C Actions
+     */
+    zuluide::i2c::I2CActions i2cActions;
 
     /***
         Simple class for storing updates.
@@ -187,6 +192,10 @@ void ImageResponsePipe<SrcType>::HandleRequest(ImageRequest<SrcType>& current)
     case image_request_t::Reset:
       dbgmsg("Image response pipe is resetting");
       imageIterator.Reset();
+      return;
+    case image_request_t::WiFiConnect:
+      dbgmsg("Image response pipe attempting to connect to WiFi");
+      i2cActions.WiFiConnect();
       return;
     case image_request_t::Empty:
       dbgmsg("Requesting image was emtpy and doesn't have a source");

--- a/lib/ZuluControl/src/i2c/i2c_actions.cpp
+++ b/lib/ZuluControl/src/i2c/i2c_actions.cpp
@@ -1,0 +1,35 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2026 Rabbit Hole Computing™
+ *
+ * ZuluIDE™ firmware is licensed under the GPL version 3 or any later version. 
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version. 
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ *
+ * Under Section 7 of GPL version 3, you are granted additional
+ * permissions described in the ZuluIDE Hardware Support Library Exception
+ * (GPL-3.0_HSL_Exception.md), as published by Rabbit Hole Computing™.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+
+#include <rotary_control.h> // this makes PlatformIO's LDF happy, otherwise ZuluControl_plaftorm.h can't find it
+#include <ZuluControl_platform.h>
+#include "zuluide/i2c/i2c_actions.h"
+
+using namespace zuluide::i2c;
+void I2CActions::WiFiConnect() {
+  platform_wifi_controller_connect();
+}

--- a/lib/ZuluControl/src/i2c/i2c_server.cpp
+++ b/lib/ZuluControl/src/i2c/i2c_server.cpp
@@ -105,7 +105,7 @@ void I2CServer::HandleUpdate(const SystemStatus& current) {
     }
     else
     {
-      platform_wifi_controller_connect();
+      RequestWiFiConnect(i2c_server_source_t::None);
     }
   }
 
@@ -228,6 +228,13 @@ void I2CServer::HandleSetToCurrent(const std::unique_ptr<ImageResponse<i2c_serve
     deviceControl->LoadImageSafe(response->GetImage());
   RequestCleanup(i2c_server_source_t::SetToCurrent);
 }
+
+void I2CServer::RequestWiFiConnect(const i2c_server_source_t source)
+{
+      ImageRequest<i2c_server_source_t> connect(image_request_t::WiFiConnect, source);
+      imageRequestPipe->RequestImageSafe(connect);
+}
+
 
 void I2CServer::RequestCleanup(const i2c_server_source_t source)
 {

--- a/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.h
+++ b/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.h
@@ -22,6 +22,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
+#pragma once
+
 #include <rotary_control.h>
 #include <zuluide/observer_transfer.h>
 #include <zuluide/status/system_status.h>


### PR DESCRIPTION
Moving reading WiFi settings and attempting to reconnect from board init to SD card insert created a bug on the RP2040 where it was doing an SD card read on the second core. This caused an SD card read error because SD access is only allowed on the first core.

The fix uses the inter-core request and response system to read the settings from the first core when a SD card change is detected.
