### PR TITLE
Set IOCS16 PIO claim guard

### DIFF
--- a/lib/ZuluIDE_platform_RP2350/rp2350_ide_phy.cpp
+++ b/lib/ZuluIDE_platform_RP2350/rp2350_ide_phy.cpp
@@ -123,6 +123,7 @@ void ide_phy_config(const ide_phy_config_t* config)
         dma_channel_claim(IOCS16_DMA_CH);
         g_idecomm.iocs16_dma_channel = IOCS16_DMA_CH;
         g_idecomm.iocs16_dma_target_addr = (uint32_t)&IOCS16_PIO->txf[IOCS16_PIO_SM];
+        g_ide_phy.pio_iocs16_claimed = true;
     }
 
     // Configure the PIO block that is used for IOCS16 signal handling


### PR DESCRIPTION
There is a check to see if the IOCS16 PIO statemachine has been claimed once, but the boolean never flips after the first check. This could cause the statemachine to be claimed more than once, which could cause an error.

The is to set `g_ide_phy.pio_iocs16_claimed = true` after the check.