### PR TITLE
Stub ATAPI Synchronize Cache command

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -871,6 +871,7 @@ bool IDEATAPIDevice::handle_atapi_command(const uint8_t *cmd)
         case ATAPI_CMD_WRITE10:         return atapi_write(cmd);
         case ATAPI_CMD_WRITE12:         return atapi_write(cmd);
         case ATAPI_CMD_WRITE_AND_VERIFY10: return atapi_write(cmd);
+        case ATAPI_CMD_SYNCHRONIZE_CACHE: return atapi_cmd_ok();
 
         default:
             logmsg("-- WARNING: Unsupported ATAPI command ", get_atapi_command_name(cmd[0]));


### PR DESCRIPTION
Return atapi_cmd_ok as the command doesn't need any returned data and there is no write cache for the command to apply to as all data has already been written to the SD card.