### PR TITLE
Report error when the wrong identify is used

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -94,9 +94,9 @@ bool IDEATAPIDevice::handle_command(ide_registers_t *regs)
         case IDE_CMD_IDENTIFY_DEVICE: [[fallthrough]];
         case IDE_CMD_READ_SECTORS: [[fallthrough]];
         case IDE_CMD_READ_SECTORS_EXT:
-            return set_device_signature(IDE_ERROR_ABORT, false);
+            return set_device_signature(regs, IDE_ERROR_ABORT, false);
         case IDE_CMD_EXECUTE_DEVICE_DIAGNOSTIC:
-            return set_device_signature(IDE_ERROR_EXEC_DEV_DIAG_DEV0_PASS, false);
+            return set_device_signature(regs, IDE_ERROR_EXEC_DEV_DIAG_DEV0_PASS, false);
         // Supported IDE commands
         case IDE_CMD_NOP: return cmd_nop(regs);
         case IDE_CMD_SET_FEATURES: return cmd_set_features(regs);
@@ -125,7 +125,7 @@ void IDEATAPIDevice::handle_event(ide_event_t evt)
             m_atapi_state.unit_attention_sense_asc = ATAPI_ASC_RESET_OCCURRED;
         }
 
-        set_device_signature(0, true);
+        set_device_signature(nullptr, 0, true);
     }
 }
 
@@ -443,23 +443,28 @@ bool IDEATAPIDevice::cmd_check_power_mode(ide_registers_t *regs)
 
 // Set the packet device signature values to PHY registers
 // See T13/1410D revision 3a section 9.12 Signature and persistence
-bool IDEATAPIDevice::set_device_signature(uint8_t error, bool was_reset)
+bool IDEATAPIDevice::set_device_signature(ide_registers_t *regs, uint8_t error, bool was_reset)
 {
-    ide_registers_t regs = {};
-    ide_phy_get_regs(&regs);
+    ide_registers_t local_regs = {};
+    if (regs == nullptr)
+    {
+        regs = &local_regs;
+        ide_phy_get_regs(regs);
+    }
 
-    regs.error = error;
-    fill_device_signature(&regs);
+
+    regs->error = error;
+    fill_device_signature(regs);
 
     if (was_reset)
     {
-        regs.error = 1; // Diagnostics ok
-        regs.status = 0;
+        regs->error = 1; // Diagnostics ok
+        regs->status = 0;
     }
 
     // We might not be the currently selected device, so specify index when
     // setting the registers.
-    ide_phy_set_regs(&regs, m_devconfig.dev_index);
+    ide_phy_set_regs(regs, m_devconfig.dev_index);
 
     if (!was_reset)
     {

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -80,7 +80,7 @@ public:
 
     virtual void sd_card_inserted() override;
 
-    virtual bool set_device_signature(uint8_t error, bool was_reset) override;
+    virtual bool set_device_signature(ide_registers_t *regs, uint8_t error, bool was_reset) override;
 
     virtual void fill_device_signature(ide_registers_t *regs) override;
 

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -79,7 +79,9 @@ public:
     // Returns true if this device does not use the IORdy signal
     virtual bool disables_iordy() { return false; }
 
-    virtual bool set_device_signature(uint8_t error, bool was_reset) = 0;
+    // Sets the device signature, can be used as a ata command and passed regs
+    // or used standalone when regs == nullptr
+    virtual bool set_device_signature(ide_registers_t *regs, uint8_t error, bool was_reset) = 0;
 
     // Set signature values for ide register
     virtual void fill_device_signature(ide_registers_t *regs) = 0;

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -189,7 +189,7 @@ bool IDERigidDevice::handle_command(ide_registers_t *regs)
         // sure we appear like non-ATAPI device.
         case IDE_CMD_DEVICE_RESET:
         case IDE_CMD_IDENTIFY_PACKET_DEVICE:
-            return set_device_signature(IDE_ERROR_ABORT, false);
+            return set_device_signature(regs, IDE_ERROR_ABORT, false);
 
         // Supported IDE commands
         case IDE_CMD_NOP: return cmd_nop(regs);
@@ -884,29 +884,34 @@ void IDERigidDevice::handle_event(ide_event_t evt)
             m_ata_state.udma_mode = -1;
         }
 
-        set_device_signature(0, true);
+        set_device_signature(nullptr, 0, true);
     }
 }
 
 // Set non-packet device signature values to PHY registers
 // See T13/1410D revision 3a section 9.12 Signature and persistence
-bool IDERigidDevice::set_device_signature(uint8_t error, bool was_reset)
+bool IDERigidDevice::set_device_signature(ide_registers_t* regs, uint8_t error, bool was_reset)
 {
-    ide_registers_t regs = {};
-    ide_phy_get_regs(&regs);
+    ide_registers_t local_regs = {};
+    if (regs == nullptr)
+    {
+        regs = &local_regs;
+        ide_phy_get_regs(regs);
+    }
+    
 
-    regs.error = error;
-    fill_device_signature(&regs);
+    regs->error = error;
+    fill_device_signature(regs);
 
     if (was_reset)
     {
-        regs.error = 1; // Diagnostics ok
-        regs.status = IDE_STATUS_DEVRDY | IDE_STATUS_DSC;
+        regs->error = 1; // Diagnostics ok
+        regs->status = IDE_STATUS_DEVRDY | IDE_STATUS_DSC;
     }
 
     // We might not be the currently selected device, so specify index when
     // setting the registers.
-    ide_phy_set_regs(&regs, m_devconfig.dev_index);
+    ide_phy_set_regs(regs, m_devconfig.dev_index);
 
     if (!was_reset)
     {

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -64,7 +64,7 @@ public:
 
     virtual uint64_t capacity_lba() { return capacity() / m_devinfo.bytes_per_sector; }
 
-    virtual bool set_device_signature(uint8_t error, bool was_reset) override;
+    virtual bool set_device_signature(ide_registers_t *regs, uint8_t error, bool was_reset) override;
 
     virtual void fill_device_signature(ide_registers_t *regs) override;
 


### PR DESCRIPTION
If the wrong Identify Device is received, report the command erred.

Previously when and Identify Device was used on a ATAPI device or Identify Device Packet was used on non ATAPI device, the ATA command would silently error. The underlying issue was that the regs pointer in the ATA command handler was not being passed to set_device_signature() so later in error reporting code when registers are being checked for errors the regs pointer never recorded the error in the first place.

set_device_signature() now takes the regs pointer as a parameter. The function is also called outside of the ATA command handler, so if the regs pointer is set to nullptr, it will work the same as it did before the change.