### PR TITLE
Add config options for delay after each block transfer

### DIFF
--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -552,7 +552,8 @@ bool IDEATAPIDevice::atapi_send_data(const uint8_t *data, size_t blocksize, size
 ssize_t IDEATAPIDevice::atapi_send_data_async(const uint8_t *data, size_t blocksize, size_t num_blocks)
 {
     if (m_atapi_state.data_state == ATAPI_DATA_WRITE &&
-        blocksize == m_atapi_state.blocksize)
+        blocksize == m_atapi_state.blocksize &&
+        m_devconfig.block_read_delay_us <= 0)
     {
         // Fast path, transfer size has already been set up
         size_t blocks_sent = 0;
@@ -668,6 +669,12 @@ bool IDEATAPIDevice::atapi_send_data_block(const uint8_t *data, uint16_t blocksi
         ide_phy_write_block(data, blocksize);
     }
 
+    if (m_devconfig.block_read_delay_us > 0)
+    {
+        atapi_send_wait_finish();
+        delayMicroseconds(m_devconfig.block_read_delay_us);
+    }
+
     return true;
 }
 
@@ -756,6 +763,11 @@ bool IDEATAPIDevice::atapi_recv_data(uint8_t *data, size_t blocksize, size_t num
             }
         }
 
+        if (m_devconfig.block_write_delay_us > 0)
+        {
+            delayMicroseconds(m_devconfig.block_write_delay_us);
+        }
+
         // Read out previous block
         bool continue_transfer = (i + 1 < num_blocks);
         ide_phy_read_block(data + blocksize * i, blocksize, continue_transfer);
@@ -768,6 +780,7 @@ bool IDEATAPIDevice::atapi_recv_data(uint8_t *data, size_t blocksize, size_t num
         logmsg("IDEATAPIDevice::atapi_recv_data UDMA checksum errors: ", (int)m_atapi_state.crc_errors);
         return false;
     }
+
     return true;
 }
 
@@ -803,6 +816,11 @@ bool IDEATAPIDevice::atapi_recv_data_block(uint8_t *data, uint16_t blocksize)
             ide_phy_print_debug();
             return false;
         }
+    }
+
+    if (m_devconfig.block_write_delay_us > 0)
+    {
+        delayMicroseconds(m_devconfig.block_write_delay_us);
     }
 
     ide_phy_read_block(data, blocksize);

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -546,6 +546,8 @@ void IDEDevice::initialize(int devidx)
     m_devconfig.ide_cylinders = ini_getl("IDE", "cylinders", 0, CONFIGFILE);
     m_devconfig.access_delay = ini_getl("IDE", "access_delay", 0, CONFIGFILE);
     m_devconfig.ide_identify_gencfg = ini_getl("IDE", "identify_gencfg", 0, CONFIGFILE);
+    m_devconfig.block_read_delay_us = ini_getl("IDE", "block_read_delay_us", 0, CONFIGFILE);
+    m_devconfig.block_write_delay_us = ini_getl("IDE", "block_write_delay_us", 0, CONFIGFILE);
 
     g_ignore_cmd_interrupt = ini_getl("IDE", "ignore_command_interrupt", 1, CONFIGFILE);
     m_phy_caps.max_udma_mode = std::min(m_phy_caps.max_udma_mode, m_devconfig.max_udma_mode);

--- a/src/ide_protocol.h
+++ b/src/ide_protocol.h
@@ -132,6 +132,8 @@ protected:
         int ide_sectors;
         int access_delay;
         int ide_identify_gencfg;
+        int block_read_delay_us;
+        int block_write_delay_us;
     } m_devconfig;
 
     // PHY capabilities limited by active device configuration

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -977,7 +977,9 @@ bool IDERigidDevice::ata_send_chunked_data(const uint8_t *data, size_t blocksize
 
 ssize_t IDERigidDevice::ata_send_data(const uint8_t *data, size_t blocksize, size_t num_blocks)
 {
-    if (m_ata_state.data_state == ATA_DATA_WRITE && blocksize == m_ata_state.blocksize)
+    if (m_ata_state.data_state == ATA_DATA_WRITE &&
+        blocksize == m_ata_state.blocksize &&
+        m_devconfig.block_read_delay_us <= 0)
     {
         // Fast path, transfer size has already been set up
         size_t blocks_sent = 0;
@@ -1066,6 +1068,15 @@ bool IDERigidDevice::ata_send_data_block(const uint8_t *data, uint16_t blocksize
         ide_phy_write_block(data, blocksize);
     }
 
+    if (m_devconfig.block_read_delay_us > 0)
+    {
+        // Simulate slow drives of late 1980s which only have buffer space
+        // for a single sector. Indication of needing this delay is typically
+        // multi-sector reads getting stuck but single-sector reads working.
+        ata_send_wait_finish();
+        delayMicroseconds(m_devconfig.block_read_delay_us);
+    }
+
     return true;
 }
 
@@ -1143,6 +1154,11 @@ bool IDERigidDevice::ata_recv_data(uint8_t *data, size_t blocksize, size_t num_b
             }
         }
 
+        if (m_devconfig.block_write_delay_us > 0)
+        {
+            delayMicroseconds(m_devconfig.block_write_delay_us);
+        }
+
         // Read out previous block
         bool continue_transfer = (i + 1 < num_blocks);
         // dbgmsg("Reading datablock ", (int)i, " continue ", continue_transfer);
@@ -1191,8 +1207,14 @@ bool IDERigidDevice::ata_recv_data_block(uint8_t *data, uint16_t blocksize)
         }
     }
 
+    if (m_devconfig.block_write_delay_us > 0)
+    {
+        delayMicroseconds(m_devconfig.block_write_delay_us);
+    }
+
     ide_phy_read_block(data, blocksize);
     ide_phy_stop_transfers();
+
     return true;
 }
 
@@ -1202,6 +1224,7 @@ bool IDERigidDevice::ata_recv_data_block(uint8_t *data, uint16_t blocksize)
 ssize_t IDERigidDevice::read_callback(const uint8_t *data, size_t blocksize, size_t num_blocks)
 {
     platform_poll();
+
     return ata_send_data(data, blocksize, num_blocks);
 }
 

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -64,6 +64,9 @@
 # sectors = 63
 # access_delay = 0   # Add extra delay (milliseconds) before answering to commands
 
+# block_read_delay_us = 0   # Add delay after each sector read from device, try e.g. 100 us for 386-era machines
+# block_write_delay_us = 0  # Add delay after each sector written to device
+
 # max_volume = 100 # Audio max volume 0 - 100 (default)
 
 # Logic sniffer for debugging IDE bus issues (only supported on RP2350 hardware, do not enable unless you know what you're doing, or have been asked to do so)


### PR DESCRIPTION
Some 386-era hosts expect the drive to only have buffer space for one sector, and that it won't be immediately ready again after a sector transfer. See e.g. issue #346.

@morio If you can take a quick look to check for any silly mistakes, that would be great!