### PR TITLE
Add basic log rotation by default and a log_rotate settting for zuluide.ini

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -431,6 +431,98 @@ void init_logfile()
 {
     static bool first_open_after_boot = true;
 
+    if (first_open_after_boot)
+    {
+        // Rotate file to LOGFILEPREV
+        int log_rotate = ini_getl("IDE", "log_rotate", 1, CONFIGFILE);
+        if (log_rotate == 1 || log_rotate == 2)
+        {
+            FsFile prev_log_file = SD.open(LOGFILE, O_RDONLY);
+            if (prev_log_file.isOpen())
+            {
+                if (SD.exists(LOGFILEPREV))
+                {
+                    SD.remove(LOGFILEPREV);
+                }
+                prev_log_file.rename(LOGFILEPREV);
+                prev_log_file.close();
+            }
+        }
+
+        // Copy LOGFILEPREV to a numbered file in the LOGFILEDIR directory
+        if (log_rotate == 2)
+        {
+            // Attempt to open or create the log rotation directory
+            FsFile prev_log_file = SD.open(LOGFILEPREV, O_RDONLY);
+            if (prev_log_file.isOpen())
+            {
+                FsFile log_dir = SD.open(LOGFILEDIR, O_RDWR);
+                if (!log_dir.isOpen())
+                {
+                    SD.mkdir(LOGFILEDIR);
+                    log_dir = SD.open(LOGFILEDIR);
+                }
+
+                if (log_dir.isOpen() && log_dir.isDir())
+                {
+                    char filename[32] = {0};
+                    for (uint32_t i = 0; i <= 1000; i++)
+                    {
+                        if (i >= 1000)
+                        {
+                            logmsg("Rotation maximum reached, please delete files in the ", LOGFILEDIR, " directory");
+                            break;
+                        }
+                        else
+                        {
+                            // format file as LOGFILEROTATE(nnn).txt
+                            snprintf(filename, sizeof(filename), "%s(%03lu).txt", LOGFILEROTATE, i);
+                            if (log_dir.exists(filename))
+                                continue;
+
+                            // Create and copy the file
+                            FsFile destination;
+                            if (destination.open(&log_dir, filename, O_CREAT | O_WRONLY))
+                            {
+                                // Write a copy of the LOGFILEPREV in the LOGFILEDIR directory
+                                while (true)
+                                {
+                                    size_t bytes_read = prev_log_file.readBytes((uint8_t*)g_ide_buffer, sizeof(g_ide_buffer));
+                                    if (bytes_read)
+                                    {
+                                        size_t bytes_written = destination.write((uint8_t*)g_ide_buffer, bytes_read);
+                                        if (bytes_written != bytes_read)
+                                        {
+                                            logmsg("Log rotation error copying ", LOGFILEPREV, " to ", filename);
+                                            break;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        break;
+                                    }
+                                }
+                                destination.close();
+                                break;
+                            }
+                            else
+                            {
+                                logmsg("Log rotation could not create ", filename, " in ", LOGFILEDIR);
+                                break;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    logmsg("Log rotation could not open ", LOGFILEDIR, " as a directory");
+                }
+                log_dir.close();
+            }
+            prev_log_file.close();
+        }
+    }
+
     bool truncate = first_open_after_boot;
     int flags = O_WRONLY | O_CREAT | (truncate ? O_TRUNC : O_APPEND);
     g_logfile = SD.open(LOGFILE, flags);

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -36,11 +36,14 @@
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths
-#define CONFIGFILE  "zuluide.ini"
-#define LOGFILE     "zululog.txt"
-#define CRASHFILE   "zuluerr.txt"
-#define LICENSEFILE "zuluide.lic"
-#define LASTFILE    "zululast.txt"
+#define CONFIGFILE    "zuluide.ini"
+#define LOGFILE       "zululog.txt"
+#define LOGFILEPREV   "zululog_prev.txt"
+#define LOGFILEDIR    "zuluide_log"
+#define LOGFILEROTATE "zululog_rotate"
+#define CRASHFILE     "zuluerr.txt"
+#define LICENSEFILE   "zuluide.lic"
+#define LASTFILE      "zululast.txt"
 
 // File names used for firmware update from SD card
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -20,6 +20,9 @@
 # you do not change any settings from the default unless instructed to do so by documentation or Rabbit Hole Computing Support
 
 # debug = 1  # Enable debug log (overrides DIP switch setting)
+# log_rotate = 0 # Disable log rotation
+# log_rotate = 1 # Rotate log to zuluide_prev.txt (default)
+# log_rotate = 2 # Save all rotated logs to `/zuluide_log/`
 
 # enable_usb_mass_storage = 0 # Disabled by default, set to 1 to enable access via USB mass storage
 


### PR DESCRIPTION
By default log rotation will save a copy of the previous log file as `zululog_prev.txt` before creating a new `zululog.txt`.

There is now a `log_rotate` setting for the `[IDE]` section in the `zuluide.ini` file.
 - `log_rotate` = 0 - disables log rotation and `zululog_prev.txt` will not be created or overwritten
 - `log_rotate` = 1 - is the default behavior and renames the previous `zululog.txt` as `zululog_prev.txt`
 - `log_rotate` = 2 - will create a `zuluide_log` directory and copies a `zululog_prev.txt` file to that directory with the name `zululog_rotate(nnn).txt` where nnn is a zero padded number between 000 - 999 where the higher number is the most recent.