### PR TITLE
Exclude zulu* directories and use SDFat calls for rotating logs

### DIFF
--- a/lib/ZuluControl/src/images/image_iterator.cpp
+++ b/lib/ZuluControl/src/images/image_iterator.cpp
@@ -336,6 +336,12 @@ bool ImageIterator::fileIsValidImage(FsFile& file, const char* fileName, bool wa
       if (warning) logmsg("-- Ignoring directory \"",fileName,"\", first character is not alphanumeric");
       return false;
     }
+
+    if (strncasecmp(fileName, "zulu", 4) == 0) {
+      // Ignore all files that start with "zulu"
+      return false;
+    }
+
     if (!folderContainsCueSheet(file))
     {
       if (warning) logmsg("-- Ignoring directory \"",fileName,"\", no .cue file found within or .cue filename exceeds max length ", MAX_FILE_PATH - 1);

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -487,17 +487,22 @@ void init_logfile()
                                 // Write a copy of the LOGFILEPREV in the LOGFILEDIR directory
                                 while (true)
                                 {
-                                    size_t bytes_read = prev_log_file.readBytes((uint8_t*)g_ide_buffer, sizeof(g_ide_buffer));
-                                    if (bytes_read)
+                                    int bytes_read = prev_log_file.read(g_ide_buffer, sizeof(g_ide_buffer));
+                                    if (bytes_read < 0)
                                     {
-                                        size_t bytes_written = destination.write((uint8_t*)g_ide_buffer, bytes_read);
+                                        logmsg("Log rotation error reading ", LOGFILEPREV, " to buffer");
+                                        break;
+                                    }
+                                    if (bytes_read > 0)
+                                    {
+                                        size_t bytes_written = destination.write((void *)g_ide_buffer, bytes_read);
                                         if (bytes_written != bytes_read)
                                         {
-                                            logmsg("Log rotation error copying ", LOGFILEPREV, " to ", filename);
+                                            logmsg("Log rotation error writing ", LOGFILEPREV, " to ", filename);
                                             break;
                                         }
                                     }
-                                    else
+                                    if (bytes_read != sizeof(g_ide_buffer))
                                     {
                                         break;
                                     }


### PR DESCRIPTION
Now that rotating logs can create a zuluide_log directory, all zulu* directories are ignored from being image directories.

Uses the lower level read and write from the SDFat library for creating log rotation files in the zuluide_log directory instead of higher level Arduino calls.