### PR TITLE
Given preference to image files with four-letter device prefixes upon firmware initialization

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -993,7 +993,7 @@ void loadFirstImage() {
       {
         // If a prefix is used to define the drive type, only load prefix images for the first image
         if (prefix[0] != '\0'
-          && imgIterator.Get().GetImageType() != Image::InferImageTypeFromImagePrefix(prefix)
+          && strncasecmp(imgIterator.Get().GetFilename().c_str(), prefix, 4) != 0
         )
         {
           continue;


### PR DESCRIPTION
This commit corrects a condition where, when there are two images are in the root directory, `CDRM my cd.iso` would set the device type to CD-ROM but on the first image _loaded_ would be different, if another image file exists in the root directory, AND it happens to be alphabetically ahead of CDRM, such as `A.iso` or `B.iso`

Image files prefixed with a four-letter device type will now be given preference over images without a device-type prefix. 

If the firmware detects a previously-loaded image (zululast.txt), then that image will be re-loaded at firmware initialization, instead of `CDRM my cd.iso` _as long as_ it is of the same device type. (CD-ROM, in this case)