### PR TITLE
Support the new ZuluControl-firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,25 @@ Project structure
 - **lib/ZuluIDE_platform_RP2040**: Platform-specific code for RP2040. Includes low level IDE bus access code.
 - **lib/minIni**: Ini config file access library
 
+ZuluControl-firmware
+--------------------
+For the latest see [ZuluControl-firmware](https://github.com/rabbitholecomputing/ZuluControl-firmware)
+
+When the ZuluIDE is hooked up to a WiFi enabled expansion board over I2C running ZuluControl-firmware,
+the ZuluIDE drive images can be controlled via a web interface.
+To initiate the support, the following settings are need in the `zuluide.ini` file under the
+`[UI]` section:
+```
+[UI]
+wifissid="MY_NETWORK_SSID" # SSID for the WIFI network
+wifipassword="MY_PASSWORD" # Password for the WIFI network.
+
+# Static IP configuration (optional, DHCP is the default)
+wifi_static_ip="192.168.1.42"
+wifi_static_netmask="255.255.255.0"
+wifi_static_gateway="192.168.1.1"
+```
+
 Building
 --------
 This codebase uses [PlatformIO](https://platformio.org/).

--- a/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
+++ b/lib/ZuluControl/include/zuluide/i2c/i2c_server.h
@@ -33,7 +33,7 @@
 #include "i2c_server_src_type.h"
 #include <string>
 
-#define I2C_API_VERSION "3.2.1"
+#define I2C_API_VERSION "4.0.0"
 
 // Delay between reading the filenames off the SD card in milliseconds
 #ifndef I2C_FILENAME_TRANSFER_DELAY
@@ -52,6 +52,9 @@
 #define I2C_SERVER_RESET 0xF
 #define I2C_SERVER_STATIC_IP 0x10
 #define I2C_SERVER_IP_ADDRESS_ACK 0x11
+#define I2C_SERVER_SD_STATUS_CHANGE 0x13  // SD card presence changed; payload[0] = 0x00 not present, 0x01 present
+#define I2C_SERVER_SD_NOT_PRESENT 0x00
+#define I2C_SERVER_SD_PRESENT     0x01
 
 #define I2C_CLIENT_NOOP 0x0
 
@@ -214,6 +217,7 @@ namespace zuluide::i2c {
     TwoWire* wire;
     DeviceControlSafe* deviceControl;
     bool isSubscribed;
+    bool apiVersionSent;
     bool devControlSet;
     bool sendFilenames;
     bool sendFiles;
@@ -221,6 +225,7 @@ namespace zuluide::i2c {
     bool updateFilenameCache;
     bool isIterating;
     bool isPresent;
+    bool lastCardPresent;
     std::string status;
     std::string ssid;
     std::string password;

--- a/lib/ZuluControl/src/i2c/i2c_server.cpp
+++ b/lib/ZuluControl/src/i2c/i2c_server.cpp
@@ -44,8 +44,8 @@ using namespace zuluide::i2c;
 I2CServer::I2CServer(ImageRequestPipe<i2c_server_source_t>* image_request_pipe, ImageResponsePipe<i2c_server_source_t>* image_response_pipe) : 
   imageRequestPipe(image_request_pipe), imageResponsePipe(image_response_pipe),
   filenameTransferState(FilenameTransferState::Idle), deviceControl(nullptr),
-  isSubscribed(false), devControlSet(false), sendFilenames(false), sendFiles(false),
-  sendNextImage(false), updateFilenameCache(false), isIterating(false), isPresent(false), password(""), ip(""), netmask(""), gateway(""), remoteMajorVersion(0)
+  isSubscribed(false), apiVersionSent(false), devControlSet(false), sendFilenames(false), sendFiles(false),
+  sendNextImage(false), updateFilenameCache(false), isIterating(false), isPresent(false), lastCardPresent(false), password(""), ip(""), netmask(""), gateway(""), remoteMajorVersion(0)
 {
   imageResponsePipe->AddObserver([&](const ImageResponse<i2c_server_source_t>& t){HandleImageResponse(t);});
 }
@@ -88,17 +88,23 @@ bool writeLengthPrefacedString(TwoWire *wire, uint8_t reg, uint16_t length, cons
 }
 
 bool I2CServer::CheckForDevice() {
+  apiVersionSent = false;
   auto buf = "";
   isPresent = writeLengthPrefacedString(wire, I2C_SERVER_RESET, 0, buf);
+  if (isPresent) {
+    static const char ide_api_ver[] = I2C_API_VERSION " ZuluIDE";
+    if (writeLengthPrefacedString(wire, I2C_SERVER_API_VERSION, strlen(ide_api_ver), ide_api_ver)) {
+      apiVersionSent = true;
+    }
+  }
   return isPresent;
 }
 
 void I2CServer::HandleUpdate(const SystemStatus& current) {
-  static bool lastCardPresentStatus = false;
   bool card_present = current.IsCardPresent();
-  if (lastCardPresentStatus != card_present) {
+  if (lastCardPresent != card_present) {
     updateFilenameCache = card_present;
-    lastCardPresentStatus = card_present;
+    lastCardPresent = card_present;
     if (!card_present)
     {
       RequestCleanup(i2c_server_source_t::None);
@@ -106,6 +112,11 @@ void I2CServer::HandleUpdate(const SystemStatus& current) {
     else
     {
       RequestWiFiConnect(i2c_server_source_t::None);
+    }
+    if (isPresent)
+    {
+      const uint8_t sd_payload = card_present ? I2C_SERVER_SD_PRESENT : I2C_SERVER_SD_NOT_PRESENT;
+      writeLengthPrefacedString(wire, I2C_SERVER_SD_STATUS_CHANGE, 1, (const char*)&sd_payload);
     }
   }
 
@@ -380,7 +391,21 @@ void I2CServer::Poll() {
           logmsg("I2C client failed to send API version I2C server API verion. Please upgrade both devices to the latest firmware");
 
       }
-      writeLengthPrefacedString(wire, I2C_SERVER_API_VERSION, strlen(I2C_API_VERSION), I2C_API_VERSION);
+
+      if (apiVersionSent)
+      {
+        // Expected reply to our CheckForDevice() send — consume it, no write-back needed.
+        apiVersionSent = false;
+      }
+      else
+      {
+        // ZuluControl has reset and is requesting our version — write back to complete handshake.
+        isSubscribed = false;
+        updateFilenameCache = true;
+        static const char ide_api_ver[] = I2C_API_VERSION " ZuluIDE";
+        writeLengthPrefacedString(wire, I2C_SERVER_API_VERSION, strlen(ide_api_ver), ide_api_ver);
+      }
+
       delete[] buffer;
     }
     ExitLoggingSafe();
@@ -393,10 +418,15 @@ void I2CServer::Poll() {
     if (ReadInLength(wire) != 0) {
       logmsg("Length was not 0 for subscribe request.");
     }
-    
+
     logmsg("I2C Client subscribed to updates.");
-    isSubscribed = true;    
-    
+    isSubscribed = true;
+
+    // Push current SD card status so the client has it immediately on subscribe.
+    {
+      const uint8_t sd_payload = lastCardPresent ? I2C_SERVER_SD_PRESENT : I2C_SERVER_SD_NOT_PRESENT;
+      writeLengthPrefacedString(wire, I2C_SERVER_SD_STATUS_CHANGE, 1, (const char*)&sd_payload);
+    }
     // Send over the current status.
     writeLengthPrefacedString(wire, I2C_SERVER_SYSTEM_STATUS_JSON, status.length(), status.c_str());
     ExitLoggingSafe();

--- a/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.cpp
@@ -43,7 +43,7 @@ uint8_t platform_check_for_controller()
     static uint8_t controller_found = 0;
     if (checked) return controller_found;
     g_wire.setClock(100000);
-    // Setting the drive strength seems to help the I2C bus with the Pico W controller and the controller OLED display
+    // Setting the drive strength seems to help the I2C bus with the ZuluControl and the controller OLED display
     // to communicate and handshake properly
     gpio_set_drive_strength(GPIO_I2C_SCL, GPIO_DRIVE_STRENGTH_12MA);
     gpio_set_drive_strength(GPIO_I2C_SDA, GPIO_DRIVE_STRENGTH_12MA);


### PR DESCRIPTION
Changed ZuluIDE firmware to work with the new Web UI firmware that works with both ZuluIDE and ZuluSCSI.

The `ZuluIDE-HTTP-PicoW` firmware has been switched and renamed, `ZuluControl-firmware`, and is located here:
https://github.com/rabbitholecomputing/ZuluControl-firmware

The ZuluControl-firmware API version is now 4.0.0

Changes
- SD Card: Present/Not Present status has been added
- If there is no image loaded, instead of blank text it reports `(no image)`