### PR TITLE
Preemptive fix to move the ZuluControl-firmware update filename buffer to heap

### DIFF
--- a/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.cpp
@@ -168,10 +168,10 @@ uint8_t platform_check_for_controller()
     {
         FsFile root = SD.open("/");
         FsFile file;
+        char *filename = new char[MAX_FILE_PATH+1];
         while (file.openNext(&root))
         {
-            char filename[MAX_FILE_PATH];
-            file.getName(filename, sizeof(filename));
+            file.getName(filename, MAX_FILE_PATH+1);
             const char *extension = strrchr(filename, '.');
             if (extension 
                 && strncasecmp(extension, ".uf2", 4) == 0
@@ -183,6 +183,8 @@ uint8_t platform_check_for_controller()
                 break;
             }
         }
+        delete[] filename;
+        filename = nullptr;
         file.close();
         root.close();
 


### PR DESCRIPTION
In ZuluSCSI the searching for the ZuluControl-firmware update file used a filename buffer on the stack that sometimes caused a stack overflow crash. The fix was to move it to the heap.

This is a preemptive fix that does the same.