### PR TITLE
Add ATA security command logging + PIO password capture for Denso TSC debugging

### DIFF
--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -232,20 +232,15 @@ bool IDERigidDevice::handle_command(ide_registers_t *regs)
         // logged to zululog.txt and flushed to the SD card immediately so the
         // trace survives a host-driven reset right after the unlock.
         case IDE_CMD_SECURITY_SET_PASSWORD:
-            log_security_event("SET_PASSWORD", 0xF1, regs);
-            return true;
+            return cmd_security_password(regs, "SET_PASSWORD", 0xF1);
         case IDE_CMD_SECURITY_UNLOCK:
-            log_security_event("UNLOCK", 0xF2, regs);
-            return true;
+            return cmd_security_password(regs, "UNLOCK", 0xF2);
         case IDE_CMD_SECURITY_ERASE_PREPARE:
-            log_security_event("ERASE_PREPARE", 0xF3, regs);
-            return true;
+            return cmd_security_ack(regs);
         case IDE_CMD_SECURITY_FREEZE_LOCK:
-            log_security_event("FREEZE_LOCK", 0xF5, regs);
-            return true;
+            return cmd_security_ack(regs);
         case IDE_CMD_SECURITY_DISABLE_PASSWORD:
-            log_security_event("DISABLE_PASSWORD", 0xF6, regs);
-            return true;
+            return cmd_security_password(regs, "DISABLE_PASSWORD", 0xF6);
         default: return false;
     }
 }
@@ -917,6 +912,72 @@ void IDERigidDevice::handle_event(ide_event_t evt)
 
         set_device_signature(nullptr, 0, true);
     }
+}
+
+// ---------------------------------------------------------------------------
+// ATA Security commands: DOWNSTREAM PATCH (local-only)
+// ---------------------------------------------------------------------------
+// These commands have a PIO data-out phase: the host writes 512 bytes
+// (32-byte password padded with zeros/repeats to 512).  We:
+//   1. Initiate the PIO data transfer (signal DRQ via start_read_buffer)
+//   2. Wait for the host to send data (blocking)
+//   3. Read and log the password bytes
+//   4. Return success (no actual state change)
+//
+// For commands with no data phase (FREEZE_LOCK, ERASE_PREPARE) we just ACK.
+
+bool IDERigidDevice::cmd_security_ack(ide_registers_t *regs)
+{
+    logmsg("[SECURITY] ACK");
+    regs->status = IDE_STATUS_DEVRDY | IDE_STATUS_DSC;
+    regs->error = 0;
+    ide_phy_set_regs(regs);
+    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
+    save_logfile(true);
+    return true;
+}
+
+bool IDERigidDevice::cmd_security_password(ide_registers_t *regs,
+                                           const char *name, uint8_t opcode)
+{
+    // Per ATA/ATAPI-6 § 8.22, SECURITY_SET_PASSWORD and SECURITY_UNLOCK
+    // transfer 512 bytes PIO data-out.  The first 32 bytes are the password;
+    // the rest is vendor-specific/padding.
+    static uint8_t password_buf[512];
+
+    ide_phy_start_read_buffer(512);
+
+    // Blocking read: wait for the host to write the password data
+    uint32_t start = millis();
+    while (!ide_phy_can_read_block())
+    {
+        if ((uint32_t)(millis() - start) > 10000)
+        {
+            logmsg("[SECURITY] ", name, " PIO read timeout");
+            ide_phy_stop_transfers();
+            save_logfile(true);
+            return false;  // host will get ABORT
+        }
+        if (ide_phy_is_command_interrupted())
+        {
+            dbgmsg("[SECURITY] ", name, " interrupted");
+            ide_phy_stop_transfers();
+            save_logfile(true);
+            return false;
+        }
+    }
+
+    ide_phy_read_block(password_buf, 512, false);
+    ide_phy_stop_transfers();
+
+    // Log the event with the full 32-byte password hex dump
+    log_security_event(name, opcode, regs, password_buf, 32);
+
+    regs->status = IDE_STATUS_DEVRDY | IDE_STATUS_DSC;
+    regs->error = 0;
+    ide_phy_set_regs(regs);
+    ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_DSC);
+    return true;
 }
 
 // Set non-packet device signature values to PHY registers

--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -26,6 +26,7 @@
 #include "ide_rigid.h"
 #include "ide_utils.h"
 #include "atapi_constants.h"
+#include "ide_security_log.h"
 #include "ZuluIDE.h"
 #include "ZuluIDE_config.h"
 #include <minIni.h>
@@ -227,12 +228,23 @@ bool IDERigidDevice::handle_command(ide_registers_t *regs)
         // ATA Security commands — accept silently to placate hosts that probe or
         // attempt unlock/password sequences during startup.  No state is kept:
         // passwords are ignored, lock/unlock is a no-op, every command succeeds
-        // with no error so the host continues to the data phase.
+        // with no error so the host continues to the data phase.  Each event is
+        // logged to zululog.txt and flushed to the SD card immediately so the
+        // trace survives a host-driven reset right after the unlock.
         case IDE_CMD_SECURITY_SET_PASSWORD:
+            log_security_event("SET_PASSWORD", 0xF1, regs);
+            return true;
         case IDE_CMD_SECURITY_UNLOCK:
+            log_security_event("UNLOCK", 0xF2, regs);
+            return true;
         case IDE_CMD_SECURITY_ERASE_PREPARE:
+            log_security_event("ERASE_PREPARE", 0xF3, regs);
+            return true;
         case IDE_CMD_SECURITY_FREEZE_LOCK:
+            log_security_event("FREEZE_LOCK", 0xF5, regs);
+            return true;
         case IDE_CMD_SECURITY_DISABLE_PASSWORD:
+            log_security_event("DISABLE_PASSWORD", 0xF6, regs);
             return true;
         default: return false;
     }

--- a/src/ide_rigid.h
+++ b/src/ide_rigid.h
@@ -156,6 +156,10 @@ protected:
     virtual bool cmd_check_power_mode(ide_registers_t *regs);
     virtual bool cmd_get_media_status(ide_registers_t *regs);
 
+    // ATA Security command handlers (local fork, not for upstream)
+    virtual bool cmd_security_ack(ide_registers_t *regs);
+    virtual bool cmd_security_password(ide_registers_t *regs, const char *name, uint8_t opcode);
+
     // Helper methods
     // convert lba to cylinder, head, sector values
     void lba2chs(const uint32_t lba, uint16_t &cylinder, uint8_t &head, uint8_t &sector);

--- a/src/ide_security_log.cpp
+++ b/src/ide_security_log.cpp
@@ -1,0 +1,47 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2026 (local fork)
+ *
+ * Local-only implementation. See ide_security_log.h.
+**/
+
+#include "ide_security_log.h"
+#include "ZuluIDE_log.h"
+
+void log_security_event(const char *event, uint8_t opcode, ide_registers_t *regs,
+                        const uint8_t *password_data, size_t password_len)
+{
+    if (regs)
+    {
+        logmsg("[SECURITY] ", event,
+               " opcode=0x", (uint16_t)opcode,
+               " feat=0x", (uint16_t)regs->feature,
+               " sc=0x", (uint16_t)regs->sector_count,
+               " lba=0x", (uint32_t)((regs->lba_high << 16) | (regs->lba_mid << 8) | regs->lba_low),
+               " dev=0x", (uint16_t)regs->device);
+    }
+    else
+    {
+        logmsg("[SECURITY] ", event, " opcode=0x", (uint16_t)opcode);
+    }
+
+    if (password_data && password_len > 0)
+    {
+        // Print password bytes as hex, space-separated
+        char hexbuf[96] = {0};
+        size_t hexlen = 0;
+        const char *nibble = "0123456789ABCDEF";
+        for (size_t i = 0; i < password_len && hexlen < sizeof(hexbuf) - 4; i++)
+        {
+            hexbuf[hexlen++] = nibble[(password_data[i] >> 4) & 0xF];
+            hexbuf[hexlen++] = nibble[password_data[i] & 0xF];
+            hexbuf[hexlen++] = ' ';
+        }
+        if (hexlen > 0 && hexbuf[hexlen - 1] == ' ') hexlen--;
+        hexbuf[hexlen] = '\0';
+        logmsg("[SECURITY]   data: ", hexbuf);
+    }
+
+    // Flush to SD card immediately so the entry survives any subsequent
+    // reset triggered by the host right after a security command.
+    save_logfile(true);
+}

--- a/src/ide_security_log.h
+++ b/src/ide_security_log.h
@@ -1,0 +1,26 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2026 (local fork)
+ *
+ * Local-only utility: log ATA security command activity to zululog.txt on the
+ * SD card, then flush immediately. This is meant for debugging ATA-Security
+ * probing sequences on hosts like the Denso TSC Gen 3/4 nav module.
+ *
+ * Not for upstream submission — this is a diagnostic aid added on a local
+ * branch only. See /CODE/zuluide/README-ata-compliance.md for context.
+**/
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <ide_phy.h>
+
+// Force the SD card log buffer to be flushed to zululog.txt right now.
+// Defined in ZuluIDE.cpp — declared here so ide_rigid.cpp can call it.
+extern void save_logfile(bool always);
+
+// Log an ATA security command event to zululog.txt and flush the log to
+// disk immediately. Includes the command opcode, IDE register state, and
+// (for SECURITY_UNLOCK) the 32-byte password the host sent.
+void log_security_event(const char *event, uint8_t opcode, ide_registers_t *regs,
+                        const uint8_t *password_data = nullptr, size_t password_len = 0);


### PR DESCRIPTION
This PR adds two local-only diagnostic features for debugging Denso TSC Gen 3/4 nav unit ATA security sequences:

## Commit 1: ATA Security Command Logging
- New `src/ide_security_log.h/cpp`: logs every ATA security command to `zululog.txt` on SD card
- Includes opcode, IDE register state (feature, sector_count, LBA, device)
- Immediately flushes log to SD via `save_logfile(true)` so trace survives host reset after unlock
- `ide_rigid.cpp`: each SECURITY_* case calls `log_security_event()` before returning success

## Commit 2: PIO Data Phase Hook for Password Capture
- Implements proper PIO data-out transfer for `SECURITY_SET_PASSWORD` (0xF1), `SECURITY_UNLOCK` (0xF2), `SECURITY_DISABLE_PASSWORD` (0xF6)
- Blocks on `ide_phy_start_read_buffer(512)` waiting for host to send 512-byte payload
- Captures first 32 bytes (the password) and logs as hex dump via `log_security_event()`
- Commands without data phase (`ERASE_PREPARE`, `FREEZE_LOCK`) just ACK via `cmd_security_ack()`

**NOT for upstream** - these are debug aids for Saab 9-5 NG / Cadillac SRX head unit recovery. The `LOCAL-ONLY` prefix in commit messages indicates this.