### PR TITLE
Document disable status LED and rename ini option

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -318,6 +318,17 @@ void platform_disable_led(void)
     logmsg("Disabling status LED");
 }
 
+bool platform_is_led_enabled()
+{
+    return !g_led_disabled;
+}
+
+void platform_enable_led()
+{
+    g_led_disabled = false;
+    logmsg("Enabling status LED");
+}
+
 void platform_init_eject_button(uint8_t eject_button)
 {
     if (eject_button & 1)

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
@@ -80,6 +80,8 @@ void platform_write_led_override(bool state);
 
 // Disable the status LED
 void platform_disable_led(void);
+void platform_enable_led(void);
+bool platform_is_led_enabled(void);
 
 void platform_init_eject_button(uint8_t eject_button);
 

--- a/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.cpp
@@ -307,6 +307,17 @@ void platform_disable_led(void)
     logmsg("Disabling status LED");
 }
 
+bool platform_is_led_enabled()
+{
+    return !g_led_disabled;
+}
+
+void platform_enable_led()
+{
+    g_led_disabled = false;
+    logmsg("Enabling status LED");
+}
+
 void platform_init_eject_button(uint8_t eject_button)
 {
     if (eject_button & 1)

--- a/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.h
+++ b/lib/ZuluIDE_platform_RP2350/ZuluIDE_platform.h
@@ -86,6 +86,8 @@ void platform_write_led_override(bool state);
 
 // Disable the status LED
 void platform_disable_led(void);
+void platform_enable_led(void);
+bool platform_is_led_enabled(void);
 
 void platform_init_eject_button(uint8_t eject_button);
 

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -1156,8 +1156,7 @@ static void zuluide_reload_config()
 #endif
   }
 
-  if (ini_getbool("IDE", "DisableStatusLED", false, CONFIGFILE)
-      || ini_getbool("IDE", "disable_status_led", false, CONFIGFILE))
+  if (ini_getbool("IDE", "disable_status_led", false, CONFIGFILE))
   {
       dbgmsg("-- Disabling status LED");
       platform_disable_led();

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -1156,8 +1156,10 @@ static void zuluide_reload_config()
 #endif
   }
 
-  if (ini_getbool("IDE", "DisableStatusLED", false, CONFIGFILE))
+  if (ini_getbool("IDE", "DisableStatusLED", false, CONFIGFILE)
+      || ini_getbool("IDE", "disable_status_led", false, CONFIGFILE))
   {
+      dbgmsg("-- Disabling status LED");
       platform_disable_led();
   }
 

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -31,8 +31,8 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2026.07.18"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2026.08.03"
+#define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 
 // Configuration and log file paths

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -154,6 +154,17 @@ void ide_protocol_poll()
 
     if (evt != IDE_EVENT_NONE)
     {
+        static bool check_disabled_led_once = false;
+        if (!check_disabled_led_once && evt == IDE_EVENT_CMD )
+        {
+            if (!platform_is_led_enabled() && ini_getbool("IDE", "reenable_led_after_bus_activity", false, CONFIGFILE))
+            {
+                dbgmsg("-- Re-enabling status LED after bus activity");
+                platform_enable_led();
+            }
+            check_disabled_led_once = true;
+        }
+
         LED_ON();
 
         if (evt == IDE_EVENT_CMD)

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -58,6 +58,7 @@
 # init_with_last_used_image = 1 # Enabled by default, initialize with the last image used before power off
 
 # quiet_image_parsing = 0 # Do not log image parsing warnings and info when SD card is inserted
+# disable_status_led = 0 # Set to 1 to disable the status LED, which is enabled by default
 
 # ignore_command_interrupt = 1 # Ignore a new command interrupting the current one
 # atapi_intrq = 0 # enables the INTRQ signal during a PACKET cmd, default disabled, except for zip drives. See documentation for specifics

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -59,6 +59,7 @@
 
 # quiet_image_parsing = 0 # Do not log image parsing warnings and info when SD card is inserted
 # disable_status_led = 0 # Set to 1 to disable the status LED, which is enabled by default
+# reenable_led_after_bus_activity = 0 # set to 1 to re-enable the status LED after bus activity when disable_status_led is set to 1.
 
 # ignore_command_interrupt = 1 # Ignore a new command interrupting the current one
 # atapi_intrq = 0 # enables the INTRQ signal during a PACKET cmd, default disabled, except for zip drives. See documentation for specifics


### PR DESCRIPTION
Disabling the LED was never document in the `zuluide.ini` file. The option was called "DisableStatusLED" in the code which doesn't conform to the `zuluide.ini` option naming convention. This changes the option to "disable_status_led" and document it in the `zuluide.ini`.

It also adds the ability to only blink the LED if there is bus activity to avoid powering the LED when doing basic maintenance with the USB plugged in.

To do this both:
```
[IDE]
disable_status_led =1 
reenable_led_after_bus_activity = 1
```
must be set.

This is to resolve issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/374