### PR TITLE
Add ATA security command logging to zululog.txt

### DIFF
--- a/src/ide_rigid.cpp
+++ b/src/ide_rigid.cpp
@@ -26,6 +26,7 @@
 #include "ide_rigid.h"
 #include "ide_utils.h"
 #include "atapi_constants.h"
+#include "ide_security_log.h"
 #include "ZuluIDE.h"
 #include "ZuluIDE_config.h"
 #include <minIni.h>
@@ -227,12 +228,23 @@ bool IDERigidDevice::handle_command(ide_registers_t *regs)
         // ATA Security commands — accept silently to placate hosts that probe or
         // attempt unlock/password sequences during startup.  No state is kept:
         // passwords are ignored, lock/unlock is a no-op, every command succeeds
-        // with no error so the host continues to the data phase.
+        // with no error so the host continues to the data phase.  Each event is
+        // logged to zululog.txt and flushed to the SD card immediately so the
+        // trace survives a host-driven reset right after the unlock.
         case IDE_CMD_SECURITY_SET_PASSWORD:
+            log_security_event("SET_PASSWORD", 0xF1, regs);
+            return true;
         case IDE_CMD_SECURITY_UNLOCK:
+            log_security_event("UNLOCK", 0xF2, regs);
+            return true;
         case IDE_CMD_SECURITY_ERASE_PREPARE:
+            log_security_event("ERASE_PREPARE", 0xF3, regs);
+            return true;
         case IDE_CMD_SECURITY_FREEZE_LOCK:
+            log_security_event("FREEZE_LOCK", 0xF5, regs);
+            return true;
         case IDE_CMD_SECURITY_DISABLE_PASSWORD:
+            log_security_event("DISABLE_PASSWORD", 0xF6, regs);
             return true;
         default: return false;
     }

--- a/src/ide_security_log.cpp
+++ b/src/ide_security_log.cpp
@@ -1,0 +1,47 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2026 (local fork)
+ *
+ * Local-only implementation. See ide_security_log.h.
+**/
+
+#include "ide_security_log.h"
+#include "ZuluIDE_log.h"
+
+void log_security_event(const char *event, uint8_t opcode, ide_registers_t *regs,
+                        const uint8_t *password_data, size_t password_len)
+{
+    if (regs)
+    {
+        logmsg("[SECURITY] ", event,
+               " opcode=0x", (uint16_t)opcode,
+               " feat=0x", (uint16_t)regs->feature,
+               " sc=0x", (uint16_t)regs->sector_count,
+               " lba=0x", (uint32_t)((regs->lba_high << 16) | (regs->lba_mid << 8) | regs->lba_low),
+               " dev=0x", (uint16_t)regs->device);
+    }
+    else
+    {
+        logmsg("[SECURITY] ", event, " opcode=0x", (uint16_t)opcode);
+    }
+
+    if (password_data && password_len > 0)
+    {
+        // Print password bytes as hex, space-separated
+        char hexbuf[96] = {0};
+        size_t hexlen = 0;
+        const char *nibble = "0123456789ABCDEF";
+        for (size_t i = 0; i < password_len && hexlen < sizeof(hexbuf) - 4; i++)
+        {
+            hexbuf[hexlen++] = nibble[(password_data[i] >> 4) & 0xF];
+            hexbuf[hexlen++] = nibble[password_data[i] & 0xF];
+            hexbuf[hexlen++] = ' ';
+        }
+        if (hexlen > 0 && hexbuf[hexlen - 1] == ' ') hexlen--;
+        hexbuf[hexlen] = '\0';
+        logmsg("[SECURITY]   data: ", hexbuf);
+    }
+
+    // Flush to SD card immediately so the entry survives any subsequent
+    // reset triggered by the host right after a security command.
+    save_logfile(true);
+}

--- a/src/ide_security_log.h
+++ b/src/ide_security_log.h
@@ -1,0 +1,26 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2026 (local fork)
+ *
+ * Local-only utility: log ATA security command activity to zululog.txt on the
+ * SD card, then flush immediately. This is meant for debugging ATA-Security
+ * probing sequences on hosts like the Denso TSC Gen 3/4 nav module.
+ *
+ * Not for upstream submission — this is a diagnostic aid added on a local
+ * branch only. See /CODE/zuluide/README-ata-compliance.md for context.
+**/
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <ide_phy.h>
+
+// Force the SD card log buffer to be flushed to zululog.txt right now.
+// Defined in ZuluIDE.cpp — declared here so ide_rigid.cpp can call it.
+extern void save_logfile(bool always);
+
+// Log an ATA security command event to zululog.txt and flush the log to
+// disk immediately. Includes the command opcode, IDE register state, and
+// (for SECURITY_UNLOCK) the 32-byte password the host sent.
+void log_security_event(const char *event, uint8_t opcode, ide_registers_t *regs,
+                        const uint8_t *password_data = nullptr, size_t password_len = 0);


### PR DESCRIPTION
Logs every ATA security command (SECURITY_SET_PASSWORD, SECURITY_UNLOCK, SECURITY_ERASE_PREPARE, SECURITY_FREEZE_LOCK, SECURITY_DISABLE_PASSWORD) issued by the host to zululog.txt on the SD card, with the IDE register state, and flushes the log immediately so the trace survives a host reset right after the unlock sequence.

This debug aid helps track what hosts do during their SECURITY_UNLOCK probe sequence.

Changes:
* New src/ide_security_log.h: declares log_security_event() and an extern for save_logfile() so ide_rigid.cpp can flush the log.
* New src/ide_security_log.cpp: implements log_security_event(), formats the event with [SECURITY] prefix, IDE register state, and (optionally) hex data the host sent. Calls save_logfile(true) at the end to force a flush.
* src/ide_rigid.cpp: each SECURITY_* case now calls log_security_event() with the command name and opcode before returning success.