### PR TITLE
Fix Zip Drive image listing regression and deffered ejection to control board and to the ZuluControl-firmware

### DIFF
--- a/lib/ZuluControl/src/status/status_controller.cpp
+++ b/lib/ZuluControl/src/status/status_controller.cpp
@@ -164,9 +164,15 @@ bool StatusController::IsPreventRemovable()
 
 void StatusController::SetIsDeferred(bool defer)
 {
+  if (status.IsDeferred() == defer)
+    return;
+
   status.SetIsDeferred(defer);
-  if (!defer)
-    notifyObservers();
+  // Notify in both directions so the UI and the web interface can show a
+  // pending load/eject, not just its completion. Setting the flag often
+  // happens from inside an observer callback (e.g. load_image() or
+  // button_eject_media()); status_observer() guards against re-entry.
+  notifyObservers();
 }
 
 bool StatusController::IsDeferred()

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -998,12 +998,18 @@ void loadFirstImage() {
     {
       while(imgIterator.MoveNext())
       {
-        // If a prefix is used to define the drive type, only load prefix images for the first image
-        if (prefix[0] != '\0'
-          && strncasecmp(imgIterator.Get().GetFilename().c_str(), prefix, 4) != 0
-        )
+        // Compare by inferred drive type rather  than by an exact 4-char prefix string,
+        // so every recognized alias for a type is accepted (e.g. the "zipd" and the
+        //  other options "z100"/"z250").
+        if (prefix[0] != '\0')
         {
-          continue;
+          Image::ImageType prefix_type =
+            Image::InferImageTypeFromImagePrefix(imgIterator.Get().GetFilename().c_str());
+          if (prefix_type == Image::ImageType::unknown
+            || Image::ToDriveType(prefix_type) != g_ide_imagefile.get_drive_type())
+          {
+            continue;
+          }
         }
         logmsg("Loading first image ", imgIterator.Get().GetFilename().c_str());
         g_StatusController.LoadImage(imgIterator.Get());

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -496,6 +496,10 @@ void IDEATAPIDevice::loaded_new_media()
     m_removable.ejected = false;
     set_not_ready(true);
 
+    // Media is now loaded, so any pending deferred load has been satisfied.
+    m_removable.is_load_deferred = false;
+    g_StatusController.SetIsDeferred(false);
+
     char filename[MAX_FILE_PATH + 1];
     if (m_image && m_image->get_image_name(filename, sizeof(filename)))
     {
@@ -1645,12 +1649,29 @@ void IDEATAPIDevice::eject_button_poll(bool immediate)
     }
 }
 
+void IDEATAPIDevice::set_eject_deferred()
+{
+    dbgmsg("Ejection deferred, host is preventing media from being ejected");
+    m_removable.deferred_image_name[0] = '\0';
+    m_removable.is_load_deferred = true;
+    g_StatusController.SetIsDeferred(true);
+}
+
+void IDEATAPIDevice::clear_eject_deferred()
+{
+    if (m_removable.is_load_deferred && m_removable.deferred_image_name[0] == '\0')
+    {
+        m_removable.is_load_deferred = false;
+        g_StatusController.SetIsDeferred(false);
+    }
+}
+
 void IDEATAPIDevice::button_eject_media()
 {
  if (!m_removable.prevent_removable || m_removable.ignore_prevent_removal)
         eject_media();
     else
-        dbgmsg("Attempted to eject media but host has set drive to prevent removable");
+        set_eject_deferred();
 }
 
 void IDEATAPIDevice::eject_media()
@@ -1668,6 +1689,7 @@ void IDEATAPIDevice::eject_media()
             logmsg("Device ejecting media, image already cleared");
         }
         m_removable.ejected = true;
+        clear_eject_deferred();
     }
     else
         dbgmsg("---- Eject request ignored or delayed");

--- a/src/ide_atapi.h
+++ b/src/ide_atapi.h
@@ -95,6 +95,16 @@ public:
     virtual inline void set_load_first_image_cb(void (*load_image_cb)()) override {m_removable.load_first_image_cb = load_image_cb;}
 
 protected:
+    // Records that a user requested an eject the host is currently preventing, and
+    // reports it so the display and web interface can show the pending eject.
+    // A deferred eject is a deferred load with no image name, see the deferred
+    // handling in IDEZipDrive::atapi_start_stop_unit().
+    void set_eject_deferred();
+
+    // Clears a pending deferred eject once the media has actually been ejected.
+    // Leaves a deferred load alone, that is completed by loading the image.
+    void clear_eject_deferred();
+
     IDEImage *m_image;
 
     // Device type info is filled in by subclass

--- a/src/ide_cdrom.cpp
+++ b/src/ide_cdrom.cpp
@@ -1862,6 +1862,7 @@ void IDECDROMDevice::button_eject_media()
             if (!m_removable.ejected)
             {
                 set_esn_event(esn_event_t::MEjectRequest);
+                set_eject_deferred();
             }
         }
     }

--- a/src/ide_zipdrive.cpp
+++ b/src/ide_zipdrive.cpp
@@ -114,9 +114,9 @@ bool IDEZipDrive::handle_command(ide_registers_t *regs)
 void IDEZipDrive::eject_media()
 {
     if (m_removable.ejected) return;
-    // Set ejected before calling SetIsCardPresent — that call fires status_observer()
-    // synchronously, which calls button_eject_media() → eject_media() again.
-    // Without this guard the recursion stack-overflows.
+    // Set ejected before calling into the StatusController -- the eject fires
+    // status_observer() synchronously, which calls button_eject_media() -> eject_media()
+    // again. Without this guard the recursion stack-overflows.
     m_removable.ejected = true;
 
     char filename[MAX_FILE_PATH+1];
@@ -124,14 +124,20 @@ void IDEZipDrive::eject_media()
         logmsg("Device ejecting media: \"", filename, "\"");
     else
         logmsg("Eject requested, no media to eject");
-    g_StatusController.SetIsCardPresent(false);
+    clear_eject_deferred();
+    g_StatusController.EjectImage();
 }
 
 
 void IDEZipDrive::button_eject_media()
 {
     if (m_removable.prevent_removable)
+    {
+        // Report the eject request to the host, and show it as pending on the
+        // display and web interface until the host lets the media go.
         m_zip_disk_info.button_pressed = true;
+        set_eject_deferred();
+    }
     else
         eject_media();
 }
@@ -566,8 +572,8 @@ bool IDEZipDrive::atapi_start_stop_unit(const uint8_t *cmd)
                     }
                     else
                     {
-                        g_StatusController.SetIsDeferred(false);
-                        m_removable.is_load_deferred = false;
+                        // Deferred eject: the host is now letting the media go,
+                        // eject_media() clears the deferred state.
                         m_zip_disk_info.button_pressed = false;
                         eject_media();
                     }


### PR DESCRIPTION
Fixes a major regression where images with the `zipd` prefix were not being listed as images for Zip Drive emulation.
Fixes the Control Board and ZuluControl-firmware showing deferred loading of images for Zip Drive emulation.