### PR TITLE
Move some init log messages to debug messages

### DIFF
--- a/lib/ZuluControl/src/i2c/i2c_server.cpp
+++ b/lib/ZuluControl/src/i2c/i2c_server.cpp
@@ -533,7 +533,7 @@ void I2CServer::Poll() {
       logmsg("Length was not 0 for subscribe request.");
     }
 
-    logmsg("I2C Client subscribed to updates.");
+    dbgmsg("I2C Client subscribed to updates.");
     isSubscribed = true;
 
     // Push current SD card status so the client has it immediately on subscribe.

--- a/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2MCU/ZuluControl_platform.cpp
@@ -204,24 +204,24 @@ uint8_t platform_check_for_controller()
 }
 
 void platform_set_status_controller(zuluide::ObserverTransfer<zuluide::status::SystemStatus> *statusController) {
-    logmsg("Initialized platform controller with the status controller.");
+    dbgmsg("Initialized platform controller with the status controller.");
     display.init(&g_wire);
     statusController->AddObserver(processStatusUpdate);
     uiStatusController = statusController;
 }
 
 void platform_set_controller_image_response_pipe(zuluide::pipe::ImageResponsePipe<zuluide::control::select_controller_source_t> *imageRequestPipe) {
-    logmsg("Initialized platform with filename request pipe");
+    dbgmsg("Initialized platform with filename request pipe");
     g_controllerImageResponsePipe = imageRequestPipe;
 }
 
 void platform_set_display_controller(zuluide::Observable<zuluide::control::DisplayState>& displayController) {
-    logmsg("Initialized platform controller with the display controller.");
+    dbgmsg("Initialized platform controller with the display controller.");
     displayController.AddObserver([&] (auto current) -> void {display.HandleUpdate(current);}); 
 }
 
 void platform_set_input_interface(zuluide::control::InputReceiver* inputReceiver) {
-    logmsg("Initialized platform controller with input receiver.");
+    dbgmsg("Initialized platform controller with input receiver.");
     g_rotary_input.SetReceiver(inputReceiver);
     g_rotary_input.StartSendingEvents();
 }

--- a/src/ide_atapi.cpp
+++ b/src/ide_atapi.cpp
@@ -1686,7 +1686,7 @@ void IDEATAPIDevice::eject_media()
         }
         else
         {
-            logmsg("Device ejecting media, image already cleared");
+            dbgmsg("Device ejecting media, image already cleared");
         }
         m_removable.ejected = true;
         clear_eject_deferred();


### PR DESCRIPTION
A few initialization log messages were moved to debug messages to reduce clutter in the logs during normal operation. These messages provide no useful/actionable information to end users, and are only useful for debugging purposes.