### PR TITLE
Load first image only when SD card is present

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -900,6 +900,8 @@ void setupStatusController()
 }
 
 void loadFirstImage() {
+  if (!g_sdcard_present) return;
+  
   bool quiet = ini_getbool("IDE", "quiet_image_parsing", 0, CONFIGFILE);
   if (!quiet) logmsg("Parsing images on the SD card");
   zuluide::images::ImageIterator imgIterator;


### PR DESCRIPTION
Upon initialization, the ZuluIDE firmware would log a message stating
`Parsing images on SD card` when the SD was not physically present, or not detected.

Now the loadFirstImage() function immediately returns, when SD card is not present, avoiding the log message and executing SD card access when no card is present.