### PR TITLE
Match on any HD*.bin prefix, for dual device emulation

### DIFF
--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -582,8 +582,7 @@ drive_type_t searchForDriveType() {
 
 #ifdef ENABLE_DUAL_DEVICE
 // Find images for configuration of dual drive mode.
-// The images are called "HD0.*" and "HD1.*" so we need to find out the file extension.
-// If this returns true, ide_protocol_init() has already been called.
+// The images are prefixed with "HD0" and "HD1" 
 bool setupDualDrive(std::unique_ptr<zuluide::status::IDeviceStatus> &device)
 {
   FsFile root = SD.open("/");

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -53,10 +53,10 @@
 #define FIRMWARE_NAME_PREFIX DEF_STRINGFY(BUILD_ENV)
 #define FIRMWARE_PREFIX "ZuluIDE-FW"
 
-// Filename for image when in dual device mode
+// Filename prefix for image when in dual device mode
 // File extension can be anything
-#define DUALDRIVE_IMAGE_PRIMARY   "HD0."
-#define DUALDRIVE_IMAGE_SECONDARY "HD1."
+#define DUALDRIVE_IMAGE_PRIMARY   "HD0"
+#define DUALDRIVE_IMAGE_SECONDARY "HD1"
 
 // Maximum path length for files on SD card
 #define MAX_FILE_PATH 256


### PR DESCRIPTION
Originally the code matched too-narrowly on `HD0.*` or `HD1.*` for dual device emulation. Now, it matches a file with prefix `HD0*.img` or `HD1*.img`, so users can place description on the image filename like `HD0 my-primary-hdd.img`.